### PR TITLE
Fix pnpm PATH in CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,12 @@ jobs:
         fi
 
         # Add uv and pnpm to PATH (installed via curl scripts)
-        export PATH="$HOME/.local/share/pnpm:$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
+        # pnpm: ~/.local/share/pnpm on Linux, ~/Library/pnpm on macOS
+        export PNPM_HOME="$HOME/.local/share/pnpm"
+        if [ "$RUNNER_OS" = "macOS" ]; then
+          export PNPM_HOME="$HOME/Library/pnpm"
+        fi
+        export PATH="$PNPM_HOME:$HOME/.local/bin:$HOME/.cargo/bin:$PATH"
 
         # Check uv
         if command -v uv &> /dev/null; then


### PR DESCRIPTION
## Summary
- Fix pnpm not found in CI tests
- pnpm installs to different locations per platform:
  - Linux: `~/.local/share/pnpm`
  - macOS: `~/Library/pnpm`
- Set `PNPM_HOME` based on `RUNNER_OS` to ensure pnpm is found

## Test plan
- [ ] CI tests pass on both macOS and Ubuntu