### PR TITLE
Add uv and pnpm PATH setup to shell config

### DIFF
--- a/shell/.zsh/base.zsh
+++ b/shell/.zsh/base.zsh
@@ -19,6 +19,17 @@ function lazy_load() {
 # Initialize direnv
 eval "$(direnv hook zsh)"
 
+# uv (Python package manager) - installed to ~/.local/bin
+export PATH="$HOME/.local/bin:$PATH"
+
+# pnpm (Node package manager)
+if [[ "$OSTYPE" == darwin* ]]; then
+    export PNPM_HOME="$HOME/Library/pnpm"
+else
+    export PNPM_HOME="$HOME/.local/share/pnpm"
+fi
+export PATH="$PNPM_HOME:$PATH"
+
 # Lazy load fnm, but set up auto-use
 if [[ "$OSTYPE" == darwin* ]]; then
     lazy_load "fnm env --use-on-cd" fnm 'export PATH="$HOME/Library/Application Support/fnm:$PATH"'

--- a/shell/README.md
+++ b/shell/README.md
@@ -18,7 +18,7 @@ Cross-platform ZSH shell configuration for macOS and Linux.
 - `.zshrc`: Main shell configuration (sourced by ~/.zshrc)
 - `.zshrc.loader`: Template for ~/.zshrc loader
 - `.zsh/`: Directory containing modular shell configurations
-  - `base.zsh`: Core shell settings, performance optimizations, and utility functions
+  - `base.zsh`: Core shell settings, tool PATH setup (uv, pnpm, fnm), and performance optimizations
   - `aliases.zsh`: Command aliases and helper functions (platform-aware)
   - `shellperf.zsh`: Shell performance profiling utilities
   - `work.zsh`: Work-specific configuration (customize as needed)

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -19,6 +19,8 @@ Running `./setup` installs the following tools:
 - **starship**: Cross-shell prompt with Git integration and customization
 - **zsh-completions**: Additional completion definitions for ZSH
 
+PATH configuration for these tools is handled in `shell/.zsh/base.zsh`.
+
 ### Installation Methods
 
 | Tool | macOS | Linux |


### PR DESCRIPTION
## Summary
- Add uv PATH (`~/.local/bin`) to `base.zsh`
- Add pnpm PATH (cross-platform: `~/Library/pnpm` on macOS, `~/.local/share/pnpm` on Linux) to `base.zsh`
- Update READMEs to document that PATH configuration is handled in shell config

## Why
Tools like pnpm add themselves to `~/.zshrc` when installed, but since we use a loader architecture, the PATH setup should be in our tracked config (`base.zsh`) so it works on any machine after running setup.

## Test plan
- [ ] CI passes
- [ ] `pnpm` and `uv` are accessible after sourcing shell config