### PR TITLE
Fix Ghostty config symlinks and add shell integration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,6 +63,14 @@ jobs:
           exit 1
         fi
 
+        # Check zprofile (symlink)
+        if [ -L ~/.zprofile ]; then
+          echo "✓ ~/.zprofile linked"
+        else
+          echo "✗ ~/.zprofile not linked"
+          exit 1
+        fi
+
         # Check direnv config (symlink)
         if [ -L ~/.config/direnv/direnvrc ]; then
           echo "✓ ~/.config/direnv/direnvrc linked"
@@ -79,11 +87,27 @@ jobs:
           exit 1
         fi
 
-        # Check Ghostty config
-        if [ -L ~/.config/ghostty/config ]; then
-          echo "✓ ~/.config/ghostty/config linked"
+        # Check Ghostty config directory (entire directory is symlinked)
+        if [ -L ~/.config/ghostty ]; then
+          echo "✓ ~/.config/ghostty directory linked"
         else
-          echo "✗ ~/.config/ghostty/config not linked"
+          echo "✗ ~/.config/ghostty directory not linked"
+          exit 1
+        fi
+
+        # Verify colour schemes are accessible (relative paths in config work)
+        if [ -f ~/.config/ghostty/colours/eva01 ]; then
+          echo "✓ Ghostty colour scheme eva01 accessible"
+        else
+          echo "✗ Ghostty colour scheme eva01 not accessible"
+          exit 1
+        fi
+
+        # Check Starship config (symlink)
+        if [ -L ~/.config/starship.toml ]; then
+          echo "✓ ~/.config/starship.toml linked"
+        else
+          echo "✗ ~/.config/starship.toml not linked"
           exit 1
         fi
 
@@ -306,6 +330,13 @@ jobs:
       run: |
         echo "Verifying symlinks were recreated..."
 
+        if [ -L ~/.zprofile ]; then
+          echo "✓ .zprofile symlink recreated"
+        else
+          echo "✗ .zprofile symlink not recreated"
+          exit 1
+        fi
+
         if [ -L ~/.config/direnv/direnvrc ]; then
           echo "✓ direnvrc symlink recreated"
         else
@@ -320,10 +351,25 @@ jobs:
           exit 1
         fi
 
-        if [ -L ~/.config/ghostty/config ]; then
-          echo "✓ ghostty config symlink recreated"
+        if [ -L ~/.config/ghostty ]; then
+          echo "✓ ghostty directory symlink recreated"
         else
-          echo "✗ ghostty config symlink not recreated"
+          echo "✗ ghostty directory symlink not recreated"
+          exit 1
+        fi
+
+        # Verify colour schemes are accessible after reset
+        if [ -f ~/.config/ghostty/colours/eva01 ]; then
+          echo "✓ ghostty colour scheme accessible after reset"
+        else
+          echo "✗ ghostty colour scheme not accessible after reset"
+          exit 1
+        fi
+
+        if [ -L ~/.config/starship.toml ]; then
+          echo "✓ starship.toml symlink recreated"
+        else
+          echo "✗ starship.toml symlink not recreated"
           exit 1
         fi
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ Other Linux distributions may work but are not officially supported.
 Each component can be customized by editing its configuration:
 
 - Shell: `shell/.zsh/*.zsh`
-- Terminal: `terminal/starship.toml`, `terminal/ghostty/config`
+- Terminal: `terminal/starship.toml`, `terminal/ghostty/` (entire directory symlinked)
 - Python: `direnv/direnvrc`
 - Git: `git/.gitignore_global`
 

--- a/reset
+++ b/reset
@@ -69,14 +69,20 @@ git config --global --unset push.autoSetupRemote 2>/dev/null || true
 git config --global --unset fetch.prune 2>/dev/null || true
 git config --global --unset alias.com 2>/dev/null || true
 
-# Ghostty
-if [[ -e ~/.config/ghostty/config ]]; then
-    echo "  → Removing ~/.config/ghostty/config..."
-    rm -f ~/.config/ghostty/config
+# Ghostty (entire directory is symlinked)
+if [[ -L ~/.config/ghostty ]]; then
+    echo "  → Removing ~/.config/ghostty symlink..."
+    rm -f ~/.config/ghostty
+elif [[ -d ~/.config/ghostty ]]; then
+    echo "  → Removing ~/.config/ghostty directory..."
+    rm -rf ~/.config/ghostty
 fi
 
 # Starship
-if [[ -e ~/.config/starship.toml ]]; then
+if [[ -L ~/.config/starship.toml ]]; then
+    echo "  → Removing ~/.config/starship.toml symlink..."
+    rm -f ~/.config/starship.toml
+elif [[ -f ~/.config/starship.toml ]]; then
     echo "  → Removing ~/.config/starship.toml..."
     rm -f ~/.config/starship.toml
 fi

--- a/shell/.zshrc
+++ b/shell/.zshrc
@@ -20,12 +20,10 @@ done
 
 _shellperf_tag "base" "Loaded base configs" 2>/dev/null || true
 
-# Starship is our chosen prompt
+# Starship is our chosen prompt (config symlinked to ~/.config/starship.toml)
 if [[ ! -v evaluated_cmds[starship] ]]; then
     _shellperf_tag "base" "Loading Starship prompt" 2>/dev/null || true
     eval "$(starship init zsh)"
     evaluated_cmds[starship]=1
     _shellperf_tag "base" "Loaded Starship prompt" 2>/dev/null || true
 fi
-
-export STARSHIP_CONFIG=~/dev/setup/terminal/starship.toml

--- a/shell/.zshrc.loader
+++ b/shell/.zshrc.loader
@@ -6,6 +6,12 @@
 zmodload zsh/datetime
 typeset -g _ZSHRC_START_TIME=$EPOCHREALTIME
 
+# Ghostty shell integration (must be near top of zshrc)
+# This ensures shell integration works after exec zsh / reload
+if [[ -n "${GHOSTTY_RESOURCES_DIR}" ]]; then
+    source "${GHOSTTY_RESOURCES_DIR}/shell-integration/zsh/ghostty-integration"
+fi
+
 # Source main configuration
 source __SETUP_DIR__/shell/.zshrc
 

--- a/shell/README.md
+++ b/shell/README.md
@@ -16,7 +16,7 @@ Cross-platform ZSH shell configuration for macOS and Linux.
 
 - `.zprofile`: Environment setup loaded at login (Homebrew init on macOS)
 - `.zshrc`: Main shell configuration (sourced by ~/.zshrc)
-- `.zshrc.loader`: Template for ~/.zshrc loader
+- `.zshrc.loader`: Template for ~/.zshrc loader (includes Ghostty shell integration)
 - `.zsh/`: Directory containing modular shell configurations
   - `base.zsh`: Core shell settings, tool PATH setup (uv, pnpm, fnm), and performance optimizations
   - `aliases.zsh`: Command aliases and helper functions (platform-aware)
@@ -35,8 +35,10 @@ Cross-platform ZSH shell configuration for macOS and Linux.
 ### Built-in Commands
 
 **Shell Management:**
-- `reload` - Restart your terminal session
+- `reload` - Restart your terminal session (`exec zsh`)
 - `shellperf` - Measure shell startup time with detailed breakdown
+
+> **Note:** The `reload` alias uses `exec zsh` to replace the shell process entirely. Ghostty shell integration is manually sourced in `.zshrc.loader` to ensure it reinitializes after reload.
 
 **Docker:**
 - `dps` - Enhanced docker ps with formatted output

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -4,8 +4,9 @@ Cross-platform terminal configuration and tools setup for macOS and Linux.
 
 ## Contents
 
-- `ghostty/`: Ghostty terminal emulator configuration
-  - `config`: Ghostty configuration with Eva01-inspired color scheme
+- `ghostty/`: Ghostty terminal emulator configuration (entire directory symlinked to `~/.config/ghostty/`)
+  - `config`: Ghostty configuration with keybindings and settings
+  - `colours/`: Color schemes (eva01, eva02)
 - `iterm2/`: iTerm2 configuration (macOS)
   - `colours/`: Color schemes (`*.itermcolors`)
   - `Custom.json`: Custom iTerm2 profile
@@ -40,26 +41,47 @@ PATH configuration for these tools is handled in `shell/.zsh/base.zsh`.
 Running `./setup` will:
 1. Detect your platform (macOS or Linux)
 2. Install all required tools using the appropriate method
-3. Symlink Ghostty configuration to `~/.config/ghostty/config`
-4. Provide status feedback for each installation
+3. Symlink Ghostty directory to `~/.config/ghostty/`
+4. Symlink Starship config to `~/.config/starship.toml`
+5. Provide status feedback for each installation
 
 ## Ghostty Terminal
 
 [Ghostty](https://ghostty.org) is a modern, GPU-accelerated terminal emulator. The configuration includes:
 
 - **Font**: FiraCode Nerd Font Mono @ 12pt
-- **Color scheme**: Eva01-inspired dark theme with purple/green accents
+- **Color scheme**: Eva01-inspired dark theme with purple/green accents (switchable to eva02)
 - **Cursor**: Non-blinking block cursor
 - **Scrollback**: 1000 lines
 
 ### Configuration Location
 
-The config is symlinked from this repo:
+The entire Ghostty directory is symlinked from this repo:
 ```
-~/.config/ghostty/config → ~/dev/setup/terminal/ghostty/config
+~/.config/ghostty/ → ~/dev/setup/terminal/ghostty/
 ```
 
-Changes to the config in this repo are immediately reflected.
+This ensures relative paths in the config (like `config-file = colours/eva01`) resolve correctly. Changes to the config in this repo are immediately reflected.
+
+### Keybindings
+
+| Keybinding | Action |
+|------------|--------|
+| `Cmd+Shift+[` / `]` | Previous/next tab |
+| `Alt+Left` / `Right` | Word movement |
+| `Cmd+Left` / `Right` | Line start/end |
+| `Alt+Backspace` | Delete word backward |
+| `Cmd+Backspace` | Delete to line start |
+| `Ctrl+Backspace` | Delete word backward (alternative) |
+| `Shift+Enter` | Newline without executing (for Claude Code, etc.) |
+| `Ctrl+Enter` | Alternative modifier key |
+
+### Shell Integration
+
+Ghostty shell integration is manually sourced in the zsh loader (`.zshrc.loader`) to ensure it works after `exec zsh` (the `reload` alias). This enables:
+- Proper tab title updates
+- No false "running process" warnings when closing tabs
+- Working directory tracking
 
 ### Linux Installation
 
@@ -91,7 +113,7 @@ The custom Starship prompt is configured in `starship.toml`. It includes:
 - Docker container status
 - Language version indicators (Python, Node.js, etc.)
 
-The configuration is automatically loaded via the `STARSHIP_CONFIG` environment variable set in `.zshrc`.
+The configuration is symlinked to `~/.config/starship.toml`, which is the default location Starship looks for.
 
 ## Node.js with pnpm
 

--- a/terminal/ghostty/config
+++ b/terminal/ghostty/config
@@ -47,3 +47,12 @@ keybind = alt+backspace=esc:0x7f
 
 # Delete to line start: Cmd+Backspace
 keybind = cmd+backspace=text:\x15
+
+# Modified keys for CLI tools (Claude Code, etc.)
+# These send CSI u (fixterms) sequences that modern CLI tools recognize
+keybind = shift+enter=text:\x1b[13;2u
+keybind = ctrl+enter=text:\x1b[13;5u
+keybind = ctrl+shift+enter=text:\x1b[13;6u
+
+# Ctrl+Backspace: Delete word backward (alternative to Alt+Backspace)
+keybind = ctrl+backspace=esc:0x7f

--- a/terminal/setup
+++ b/terminal/setup
@@ -141,27 +141,55 @@ install_ghostty() {
 install_ghostty
 
 # Setup Ghostty configuration
+# We symlink the entire ghostty directory so that relative paths in config
+# (like config-file = colours/eva01) resolve correctly
 setup_ghostty_config() {
     local ghostty_config_dir="$HOME/.config/ghostty"
-    local ghostty_config_src="$SETUP_DIR/terminal/ghostty/config"
+    local ghostty_src_dir="$SETUP_DIR/terminal/ghostty"
 
-    if [ -f "$ghostty_config_src" ]; then
-        mkdir -p "$ghostty_config_dir"
-        if [ -L "$ghostty_config_dir/config" ]; then
-            echo "  ✓ Ghostty config already linked"
-        elif [ -f "$ghostty_config_dir/config" ]; then
-            echo "  → Backing up existing Ghostty config..."
-            mv "$ghostty_config_dir/config" "$ghostty_config_dir/config.backup"
-            ln -s "$ghostty_config_src" "$ghostty_config_dir/config"
-            echo "  ✓ Ghostty config linked (backup saved)"
+    if [ -d "$ghostty_src_dir" ]; then
+        # Ensure parent .config directory exists
+        mkdir -p "$HOME/.config"
+
+        if [ -L "$ghostty_config_dir" ]; then
+            echo "  ✓ Ghostty config directory already linked"
+        elif [ -d "$ghostty_config_dir" ]; then
+            echo "  → Backing up existing Ghostty config directory..."
+            mv "$ghostty_config_dir" "$ghostty_config_dir.backup"
+            ln -s "$ghostty_src_dir" "$ghostty_config_dir"
+            echo "  ✓ Ghostty config directory linked (backup saved)"
         else
-            ln -s "$ghostty_config_src" "$ghostty_config_dir/config"
-            echo "  ✓ Ghostty config linked"
+            ln -s "$ghostty_src_dir" "$ghostty_config_dir"
+            echo "  ✓ Ghostty config directory linked"
         fi
     fi
 }
 
 setup_ghostty_config
+
+# Setup Starship configuration
+setup_starship_config() {
+    local starship_config="$HOME/.config/starship.toml"
+    local starship_src="$SETUP_DIR/terminal/starship.toml"
+
+    if [ -f "$starship_src" ]; then
+        mkdir -p "$HOME/.config"
+
+        if [ -L "$starship_config" ]; then
+            echo "  ✓ Starship config already linked"
+        elif [ -f "$starship_config" ]; then
+            echo "  → Backing up existing Starship config..."
+            mv "$starship_config" "$starship_config.backup"
+            ln -s "$starship_src" "$starship_config"
+            echo "  ✓ Starship config linked (backup saved)"
+        else
+            ln -s "$starship_src" "$starship_config"
+            echo "  ✓ Starship config linked"
+        fi
+    fi
+}
+
+setup_starship_config
 
 echo ""
 echo "✓ Terminal environment setup complete!"


### PR DESCRIPTION
## Summary

- Symlink entire `ghostty/` directory instead of just `config` file, fixing `colours/eva01: FileNotFound` error on fresh installs
- Add Ghostty keybindings for CLI tools (shift+enter, ctrl+enter, ctrl+backspace)
- Add manual Ghostty shell integration to `.zshrc.loader` so it works after `exec zsh` (reload)
- Symlink `starship.toml` to `~/.config/` instead of using `STARSHIP_CONFIG` env var
- Add missing `.zprofile` symlink test
- Update documentation

## Test plan

- [ ] Run `./reset` on a fresh-ish environment
- [ ] Verify `~/.config/ghostty/` is a symlink to the repo
- [ ] Verify `~/.config/ghostty/colours/eva01` is accessible
- [ ] Verify `~/.config/starship.toml` is a symlink
- [ ] Test `reload` alias - tab title should update, no "running process" warning on close
- [ ] Test shift+enter in Claude Code
- [ ] CI passes on macOS and Ubuntu