### PR TITLE
Fix Ghostty terminfo for SSH sessions

### DIFF
--- a/shell/.zsh/base.zsh
+++ b/shell/.zsh/base.zsh
@@ -113,3 +113,8 @@ if [[ "$OSTYPE" == darwin* ]]; then
     export DATA_DIRECTORY=/Volumes/Data
     export OLLAMA_MODELS=/Volumes/Data/.ollama/models
 fi
+
+# Ghostty terminfo (required for SSH sessions since Ghostty sets TERMINFO only in its own shell)
+if [[ -d /Applications/Ghostty.app/Contents/Resources/terminfo ]]; then
+    export TERMINFO=/Applications/Ghostty.app/Contents/Resources/terminfo
+fi


### PR DESCRIPTION
## Summary
- Exports `TERMINFO` to point to Ghostty's bundled terminfo directory
- Fixes `'xterm-ghostty': unknown terminal type` errors when SSHing between Macs with Ghostty installed

## Problem
Ghostty sets `TERMINFO` only within its own shell process. When SSHing to another Mac, the remote shell doesn't know where to find the `xterm-ghostty` terminfo, causing broken terminal behavior (backspace issues, no colors, `clear` failing).

## Test plan
- [ ] SSH into a Mac with Ghostty installed
- [ ] Verify `clear` works without errors
- [ ] Verify colors display correctly