### PR TITLE
Rename repo from setup to home

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        path: setup-repo
+        path: home-repo
 
-    - name: Set SETUP_DIR environment variable
-      run: echo "SETUP_DIR=$GITHUB_WORKSPACE/setup-repo" >> $GITHUB_ENV
+    - name: Set REPO_DIR environment variable
+      run: echo "REPO_DIR=$GITHUB_WORKSPACE/home-repo" >> $GITHUB_ENV
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -47,12 +47,12 @@ jobs:
       run: |
         echo "Checking bash script syntax..."
         failed=0
-        for f in "$SETUP_DIR"/scripts/setup "$SETUP_DIR"/scripts/reset $(find "$SETUP_DIR" -name 'setup' -path '*/*/setup') "$SETUP_DIR"/lib/platform.sh; do
+        for f in "$REPO_DIR"/scripts/setup "$REPO_DIR"/scripts/reset $(find "$REPO_DIR" -name 'setup' -path '*/*/setup') "$REPO_DIR"/lib/platform.sh; do
           if [ -f "$f" ]; then
             if bash -n "$f"; then
-              echo "✓ $(echo "$f" | sed "s|$SETUP_DIR/||") syntax is valid"
+              echo "✓ $(echo "$f" | sed "s|$REPO_DIR/||") syntax is valid"
             else
-              echo "✗ $(echo "$f" | sed "s|$SETUP_DIR/||") has syntax errors"
+              echo "✗ $(echo "$f" | sed "s|$REPO_DIR/||") has syntax errors"
               failed=1
             fi
           fi
@@ -63,7 +63,7 @@ jobs:
 
     - name: Run main setup script
       run: |
-        cd $SETUP_DIR
+        cd $REPO_DIR
         ./scripts/setup
 
     - name: Verify configuration files were created
@@ -73,7 +73,7 @@ jobs:
         # Check zsh configs
         if [ -f ~/.zshrc ]; then
           echo "✓ ~/.zshrc created"
-          # Verify it sources our config (path varies based on SETUP_DIR)
+          # Verify it sources our config (path varies based on REPO_DIR)
           if grep -q "source .*/shell/.zshrc" ~/.zshrc; then
             echo "✓ ~/.zshrc sources our config"
           else
@@ -111,7 +111,7 @@ jobs:
         fi
 
         # Check git shared config exists
-        if [ -f "$SETUP_DIR/git/.gitconfig.shared" ]; then
+        if [ -f "$REPO_DIR/git/.gitconfig.shared" ]; then
           echo "✓ git/.gitconfig.shared exists"
         else
           echo "✗ git/.gitconfig.shared not found"
@@ -313,7 +313,7 @@ jobs:
         fi
 
         # Check the main config file (shell/.zshrc)
-        if zsh -n "$SETUP_DIR/shell/.zshrc"; then
+        if zsh -n "$REPO_DIR/shell/.zshrc"; then
           echo "✓ shell/.zshrc syntax is valid"
         else
           echo "✗ shell/.zshrc has syntax errors"
@@ -321,7 +321,7 @@ jobs:
         fi
 
         # Check all individual zsh config files
-        for f in "$SETUP_DIR"/shell/.zsh/*.zsh; do
+        for f in "$REPO_DIR"/shell/.zsh/*.zsh; do
           if zsh -n "$f"; then
             echo "✓ $(basename "$f") syntax is valid"
           else
@@ -351,7 +351,7 @@ jobs:
     - name: Test setup idempotency
       run: |
         echo "Testing that setup can be run multiple times..."
-        cd $SETUP_DIR
+        cd $REPO_DIR
 
         # Run setup again
         ./scripts/setup
@@ -423,7 +423,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        path: setup-repo
+        path: home-repo
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -437,27 +437,27 @@ jobs:
 
     - name: Install dependencies
       run: |
-        cd $GITHUB_WORKSPACE/setup-repo
+        cd $GITHUB_WORKSPACE/home-repo
         uv sync --group dev
 
     - name: Check formatting
       run: |
-        cd $GITHUB_WORKSPACE/setup-repo
+        cd $GITHUB_WORKSPACE/home-repo
         uv run ruff format --check
 
     - name: Lint
       run: |
-        cd $GITHUB_WORKSPACE/setup-repo
+        cd $GITHUB_WORKSPACE/home-repo
         uv run ruff check
 
     - name: Type check
       run: |
-        cd $GITHUB_WORKSPACE/setup-repo
+        cd $GITHUB_WORKSPACE/home-repo
         uv run mypy scripts/ tasks.py tests/
 
     - name: Run tests
       run: |
-        cd $GITHUB_WORKSPACE/setup-repo
+        cd $GITHUB_WORKSPACE/home-repo
         uv run pytest -v
 
   test-reset:
@@ -471,10 +471,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        path: setup-repo
+        path: home-repo
 
-    - name: Set SETUP_DIR environment variable
-      run: echo "SETUP_DIR=$GITHUB_WORKSPACE/setup-repo" >> $GITHUB_ENV
+    - name: Set REPO_DIR environment variable
+      run: echo "REPO_DIR=$GITHUB_WORKSPACE/home-repo" >> $GITHUB_ENV
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -497,13 +497,13 @@ jobs:
 
     - name: Run initial setup
       run: |
-        cd $SETUP_DIR
+        cd $REPO_DIR
         ./scripts/setup
 
     - name: Run reset script
       run: |
         echo "Testing reset script..."
-        cd $SETUP_DIR
+        cd $REPO_DIR
 
         # Run reset (auto-confirm with yes)
         echo "y" | ./scripts/reset

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ This repository contains cross-platform configuration for macOS and Linux:
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/yourusername/setup.git ~/dev/setup
+   git clone https://github.com/yourusername/home.git ~/dev/home
    ```
 
 2. Run the setup script:
    ```bash
-   cd ~/dev/setup
+   cd ~/dev/home
    ./scripts/setup
    ```
 
@@ -37,7 +37,7 @@ This repository contains cross-platform configuration for macOS and Linux:
 If something is broken or you want a fresh start, run the reset script:
 
 ```bash
-cd ~/dev/setup
+cd ~/dev/home
 ./scripts/reset
 ```
 
@@ -50,11 +50,11 @@ The reset script takes a "nuclear" approach - it deletes and recreates everythin
 
 ## Custom Installation Path
 
-By default, the setup expects to be cloned to `~/dev/setup`. If you prefer a different location:
+Scripts auto-detect the repo path, but you can override it:
 
 ```bash
-export SETUP_DIR=/path/to/your/setup
-cd $SETUP_DIR
+export REPO_DIR=/path/to/your/home
+cd $REPO_DIR
 ./scripts/setup
 ```
 
@@ -69,7 +69,7 @@ cd $SETUP_DIR
 [Learn more](terminal/README.md)
 
 ### Shell Configuration
-- Modular ZSH configuration (edit `~/dev/setup/shell/` directly)
+- Modular ZSH configuration (edit `~/dev/home/shell/` directly)
 - `~/.zshrc` acts as loader—tools can add lines without breaking config
 - Lazy loading for better startup time
 - Total startup time tracking (including tool-added lines)

--- a/direnv/README.md
+++ b/direnv/README.md
@@ -15,7 +15,7 @@ Running `./setup` will:
 2. Create the direnv config directory (`~/.config/direnv`)
 3. Symlink the direnv configuration:
    ```
-   ~/.config/direnv/direnvrc → ~/dev/setup/direnv/direnvrc
+   ~/.config/direnv/direnvrc → ~/dev/home/direnv/direnvrc
    ```
 
 Changes to `direnvrc` in this repo are immediately reflected.
@@ -31,7 +31,7 @@ Changes to `direnvrc` in this repo are immediately reflected.
 
 2. Copy the example template:
    ```bash
-   cp ~/dev/setup/direnv/.envrc.uv.example .envrc
+   cp ~/dev/home/direnv/.envrc.uv.example .envrc
    ```
 
 3. Allow direnv to activate:

--- a/direnv/setup
+++ b/direnv/setup
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-SETUP_DIR="${SETUP_DIR:-$HOME/dev/setup}"
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Source platform detection helpers
-source "$SETUP_DIR/lib/platform.sh"
+source "$REPO_DIR/lib/platform.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Direnv Setup"
@@ -42,10 +42,10 @@ if [ -L ~/.config/direnv/direnvrc ]; then
 elif [ -f ~/.config/direnv/direnvrc ]; then
     echo "  → Backing up existing direnvrc..."
     mv ~/.config/direnv/direnvrc ~/.config/direnv/direnvrc.backup
-    ln -s "$SETUP_DIR/direnv/direnvrc" ~/.config/direnv/direnvrc
+    ln -s "$REPO_DIR/direnv/direnvrc" ~/.config/direnv/direnvrc
     echo "✓ direnvrc linked (backup saved)"
 else
-    ln -s "$SETUP_DIR/direnv/direnvrc" ~/.config/direnv/direnvrc
+    ln -s "$REPO_DIR/direnv/direnvrc" ~/.config/direnv/direnvrc
     echo "✓ direnvrc linked to ~/.config/direnv/direnvrc"
 fi
 

--- a/git/.gitconfig.shared
+++ b/git/.gitconfig.shared
@@ -2,7 +2,7 @@
 # This file contains universal git settings that should be consistent across all machines.
 # Include this in your ~/.gitconfig with:
 #   [include]
-#       path = ~/dev/setup/git/.gitconfig.shared
+#       path = ~/dev/home/git/.gitconfig.shared
 
 [core]
     whitespace = trailing-space,space-before-tab

--- a/git/README.md
+++ b/git/README.md
@@ -15,7 +15,7 @@ This setup separates git configuration into two layers:
 Your local `~/.gitconfig` includes the shared config using:
 ```ini
 [include]
-    path = ~/dev/setup/git/.gitconfig.shared
+    path = ~/dev/home/git/.gitconfig.shared
 ```
 
 ## Features
@@ -61,11 +61,11 @@ Running `./setup` will:
 1. Verify Git is installed
 2. Symlink the global gitignore:
    ```
-   ~/.gitignore_global → ~/dev/setup/git/.gitignore_global
+   ~/.gitignore_global → ~/dev/home/git/.gitignore_global
    ```
 3. Configure Git to include the shared configuration:
    ```
-   git config --global include.path "~/dev/setup/git/.gitconfig.shared"
+   git config --global include.path "~/dev/home/git/.gitconfig.shared"
    ```
 
 Changes to `.gitignore_global` or `.gitconfig.shared` in this repo are immediately reflected across all Git operations.
@@ -82,7 +82,7 @@ When verifying git configuration, note the difference between `git config --glob
 **For testing/verification:**
 ```bash
 # Check include.path is set in global config
-git config --global include.path  # Returns: ~/dev/setup/git/.gitconfig.shared
+git config --global include.path  # Returns: ~/dev/home/git/.gitconfig.shared
 
 # Check settings from shared config (must omit --global to read included files)
 git config push.autosetupremote   # Returns: true (from .gitconfig.shared)

--- a/git/setup
+++ b/git/setup
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-SETUP_DIR="${SETUP_DIR:-$HOME/dev/setup}"
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Git Configuration Setup"
@@ -23,15 +23,15 @@ if [ -L ~/.gitignore_global ]; then
 elif [ -f ~/.gitignore_global ]; then
     echo "  → Backing up existing .gitignore_global..."
     mv ~/.gitignore_global ~/.gitignore_global.backup
-    ln -s "$SETUP_DIR/git/.gitignore_global" ~/.gitignore_global
+    ln -s "$REPO_DIR/git/.gitignore_global" ~/.gitignore_global
     echo "  ✓ .gitignore_global linked (backup saved)"
 else
-    ln -s "$SETUP_DIR/git/.gitignore_global" ~/.gitignore_global
+    ln -s "$REPO_DIR/git/.gitignore_global" ~/.gitignore_global
     echo "  ✓ .gitignore_global linked"
 fi
 
 # Configure git to use shared configuration
-git config --global include.path "$SETUP_DIR/git/.gitconfig.shared"
+git config --global include.path "$REPO_DIR/git/.gitconfig.shared"
 echo "  ✓ Configured git to include shared configuration"
 echo "  ✓ Shared config includes: aliases, push/fetch/merge settings, URL rewrites"
 

--- a/lazygit/setup
+++ b/lazygit/setup
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-SETUP_DIR="${SETUP_DIR:-$HOME/dev/setup}"
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Source platform detection helpers
-source "$SETUP_DIR/lib/platform.sh"
+source "$REPO_DIR/lib/platform.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Lazygit Setup"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "setup"
+name = "home"
 version = "0.1.0"
 description = "Development environment and AI CLI tools configuration"
 requires-python = ">=3.12"

--- a/scripts/reset
+++ b/scripts/reset
@@ -3,9 +3,9 @@ set -e
 
 # Thin wrapper — confirmation prompt, then delegate to invoke.
 
-SETUP_DIR="${SETUP_DIR:-$HOME/dev/setup}"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
-source "$SETUP_DIR/lib/platform.sh"
+source "$REPO_DIR/lib/platform.sh"
 
 echo "======================================"
 echo "Development Environment Reset"
@@ -29,4 +29,4 @@ fi
 
 echo ""
 
-uv run --directory "$SETUP_DIR" inv reset --yes
+uv run --directory "$REPO_DIR" inv reset --yes

--- a/scripts/setup
+++ b/scripts/setup
@@ -3,9 +3,9 @@ set -e
 
 # Thin wrapper — platform bootstrap, then delegate to invoke.
 
-SETUP_DIR="${SETUP_DIR:-$HOME/dev/setup}"
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
-source "$SETUP_DIR/lib/platform.sh"
+source "$REPO_DIR/lib/platform.sh"
 
 # Platform bootstrap (Homebrew on macOS) — must happen before uv/invoke.
 OS=$(detect_os)
@@ -25,5 +25,5 @@ case "$OS" in
         ;;
 esac
 
-uv sync --quiet --directory "$SETUP_DIR"
-uv run --directory "$SETUP_DIR" inv setup
+uv sync --quiet --directory "$REPO_DIR"
+uv run --directory "$REPO_DIR" inv setup

--- a/shell/.zsh/aliases.zsh
+++ b/shell/.zsh/aliases.zsh
@@ -10,5 +10,5 @@ alias systemctl="sudo systemctl"
 
 # Custom aliases
 alias reload="exec zsh"
-alias cdm="cd ~/dev/setup/"
+alias cdm="cd ~/dev/home/"
 alias dps='docker ps -a --format="table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"'

--- a/shell/.zshrc.loader
+++ b/shell/.zshrc.loader
@@ -13,6 +13,6 @@ if [[ -n "${GHOSTTY_RESOURCES_DIR}" ]]; then
 fi
 
 # Source main configuration
-source __SETUP_DIR__/shell/.zshrc
+source __REPO_DIR__/shell/.zshrc
 
 # Tools install themselves below this line

--- a/shell/README.md
+++ b/shell/README.md
@@ -6,11 +6,11 @@ Cross-platform ZSH shell configuration for macOS and Linux.
 
 ```
 ~/.zshrc                          # Loader file (tools add lines here)
-  └── sources ~/dev/setup/shell/.zshrc
+  └── sources ~/dev/home/shell/.zshrc
         └── sources .zsh/*.zsh    # Modular configs
 ```
 
-**Key benefit:** Tools can add lines to `~/.zshrc` without breaking your setup. Your customizations live in `~/dev/setup/shell/` and are always sourced.
+**Key benefit:** Tools can add lines to `~/.zshrc` without breaking your setup. Your customizations live in `~/dev/home/shell/` and are always sourced.
 
 ## Directory Structure
 
@@ -86,7 +86,7 @@ _shellperf_tag "tagname" "After the operation"
 Running `./setup` will:
 1. Symlink `.zprofile`:
    ```
-   ~/.zprofile → ~/dev/setup/shell/.zprofile
+   ~/.zprofile → ~/dev/home/shell/.zprofile
    ```
 2. Create/update `~/.zshrc` to source our config (preserving any existing tool additions)
 3. Prompt you to set ZSH as your default shell (if not already)
@@ -100,7 +100,7 @@ chsh -s $(which zsh)
 
 ### Customization
 
-Edit files directly in `~/dev/setup/shell/`:
+Edit files directly in `~/dev/home/shell/`:
 - Add aliases in `.zsh/aliases.zsh`
 - Add work configs in `.zsh/work.zsh`
 - Create new `.zsh/*.zsh` files (auto-sourced)

--- a/shell/setup
+++ b/shell/setup
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-SETUP_DIR="${SETUP_DIR:-$HOME/dev/setup}"
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Source platform detection helpers
-source "$SETUP_DIR/lib/platform.sh"
+source "$REPO_DIR/lib/platform.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Shell Configuration Setup"
@@ -20,16 +20,16 @@ echo "📝 Setting up shell configuration..."
 echo ""
 
 # Symlink .zprofile
-if [[ -f "$SETUP_DIR/shell/.zprofile" ]]; then
+if [[ -f "$REPO_DIR/shell/.zprofile" ]]; then
     if [[ -L ~/.zprofile ]]; then
         echo "  ✓ .zprofile already linked"
     elif [[ -f ~/.zprofile ]]; then
         echo "  → Backing up existing .zprofile..."
         mv ~/.zprofile ~/.zprofile.backup
-        ln -s "$SETUP_DIR/shell/.zprofile" ~/.zprofile
+        ln -s "$REPO_DIR/shell/.zprofile" ~/.zprofile
         echo "  ✓ .zprofile linked (backup saved)"
     else
-        ln -s "$SETUP_DIR/shell/.zprofile" ~/.zprofile
+        ln -s "$REPO_DIR/shell/.zprofile" ~/.zprofile
         echo "  ✓ .zprofile linked"
     fi
 fi
@@ -38,13 +38,13 @@ fi
 # This allows tools to add lines to ~/.zshrc without breaking our setup
 if [[ ! -f ~/.zshrc ]]; then
     # No .zshrc exists, create from loader template with correct path
-    sed "s|__SETUP_DIR__|$SETUP_DIR|g" "$SETUP_DIR/shell/.zshrc.loader" > ~/.zshrc
-    echo "  ✓ Created ~/.zshrc (sources $SETUP_DIR/shell/.zshrc)"
-elif ! grep -qF "source $SETUP_DIR/shell/.zshrc" ~/.zshrc; then
+    sed "s|__REPO_DIR__|$REPO_DIR|g" "$REPO_DIR/shell/.zshrc.loader" > ~/.zshrc
+    echo "  ✓ Created ~/.zshrc (sources $REPO_DIR/shell/.zshrc)"
+elif ! grep -qF "source $REPO_DIR/shell/.zshrc" ~/.zshrc; then
     # .zshrc exists but doesn't source our config, prepend loader content
     echo "  → Existing ~/.zshrc found, adding source line..."
     tmp_file=$(mktemp)
-    sed "s|__SETUP_DIR__|$SETUP_DIR|g" "$SETUP_DIR/shell/.zshrc.loader" > "$tmp_file"
+    sed "s|__REPO_DIR__|$REPO_DIR|g" "$REPO_DIR/shell/.zshrc.loader" > "$tmp_file"
     echo "" >> "$tmp_file"
     echo "# Previous ~/.zshrc content below" >> "$tmp_file"
     cat ~/.zshrc >> "$tmp_file"

--- a/tasks.py
+++ b/tasks.py
@@ -73,7 +73,7 @@ def _run_component(ctx: Context, component: str) -> None:
     if not script.exists():
         print(f"Warning: {script} not found, skipping")
         return
-    ctx.run(str(script), env={"SETUP_DIR": str(REPO_DIR)}, pty=True)
+    ctx.run(str(script), env={"REPO_DIR": str(REPO_DIR)}, pty=True)
 
 
 def _teardown() -> None:

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -58,7 +58,7 @@ Running `./setup` will:
 
 The entire Ghostty directory is symlinked from this repo:
 ```
-~/.config/ghostty/ → ~/dev/setup/terminal/ghostty/
+~/.config/ghostty/ → ~/dev/home/terminal/ghostty/
 ```
 
 This ensures relative paths in the config (like `config-file = colours/eva01`) resolve correctly. Changes to the config in this repo are immediately reflected.

--- a/terminal/setup
+++ b/terminal/setup
@@ -1,10 +1,10 @@
 #!/bin/bash
 set -e
 
-SETUP_DIR="${SETUP_DIR:-$HOME/dev/setup}"
+REPO_DIR="${REPO_DIR:-$(cd "$(dirname "$0")/.." && pwd)}"
 
 # Source platform detection helpers
-source "$SETUP_DIR/lib/platform.sh"
+source "$REPO_DIR/lib/platform.sh"
 
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 echo "Terminal Environment Setup"
@@ -145,7 +145,7 @@ install_ghostty
 # (like config-file = colours/eva01) resolve correctly
 setup_ghostty_config() {
     local ghostty_config_dir="$HOME/.config/ghostty"
-    local ghostty_src_dir="$SETUP_DIR/terminal/ghostty"
+    local ghostty_src_dir="$REPO_DIR/terminal/ghostty"
 
     if [ -d "$ghostty_src_dir" ]; then
         # Ensure parent .config directory exists
@@ -170,7 +170,7 @@ setup_ghostty_config
 # Setup Starship configuration
 setup_starship_config() {
     local starship_config="$HOME/.config/starship.toml"
-    local starship_src="$SETUP_DIR/terminal/starship.toml"
+    local starship_src="$REPO_DIR/terminal/starship.toml"
 
     if [ -f "$starship_src" ]; then
         mkdir -p "$HOME/.config"


### PR DESCRIPTION
### Why are you making these changes?

Rename the repo from `setup` to `home` — it manages more than just setup (AI configs, shell environment, dev tools). Also removes all hardcoded `~/dev/setup` paths by deriving `REPO_DIR` from script location via `dirname "$0"`, so the repo can live anywhere.

### How was this tested?

- `uv run ruff check` / `ruff format --check` / `mypy` / `pytest` — all pass (61/61 tests)
- Grepped entire repo for `SETUP_DIR` and `~/dev/setup` — zero remaining references