### PR TITLE
Rename repo from home to dotfiles

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        path: home-repo
+        path: dotfiles-repo
 
     - name: Set REPO_DIR environment variable
-      run: echo "REPO_DIR=$GITHUB_WORKSPACE/home-repo" >> $GITHUB_ENV
+      run: echo "REPO_DIR=$GITHUB_WORKSPACE/dotfiles-repo" >> $GITHUB_ENV
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -423,7 +423,7 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        path: home-repo
+        path: dotfiles-repo
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5
@@ -437,27 +437,27 @@ jobs:
 
     - name: Install dependencies
       run: |
-        cd $GITHUB_WORKSPACE/home-repo
+        cd $GITHUB_WORKSPACE/dotfiles-repo
         uv sync --group dev
 
     - name: Check formatting
       run: |
-        cd $GITHUB_WORKSPACE/home-repo
+        cd $GITHUB_WORKSPACE/dotfiles-repo
         uv run ruff format --check
 
     - name: Lint
       run: |
-        cd $GITHUB_WORKSPACE/home-repo
+        cd $GITHUB_WORKSPACE/dotfiles-repo
         uv run ruff check
 
     - name: Type check
       run: |
-        cd $GITHUB_WORKSPACE/home-repo
+        cd $GITHUB_WORKSPACE/dotfiles-repo
         uv run mypy scripts/ tasks.py tests/
 
     - name: Run tests
       run: |
-        cd $GITHUB_WORKSPACE/home-repo
+        cd $GITHUB_WORKSPACE/dotfiles-repo
         uv run pytest -v
 
   test-reset:
@@ -471,10 +471,10 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        path: home-repo
+        path: dotfiles-repo
 
     - name: Set REPO_DIR environment variable
-      run: echo "REPO_DIR=$GITHUB_WORKSPACE/home-repo" >> $GITHUB_ENV
+      run: echo "REPO_DIR=$GITHUB_WORKSPACE/dotfiles-repo" >> $GITHUB_ENV
 
     - name: Install uv
       uses: astral-sh/setup-uv@v5

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ This repository contains cross-platform configuration for macOS and Linux:
 
 1. Clone the repository:
    ```bash
-   git clone https://github.com/yourusername/home.git ~/dev/home
+   git clone https://github.com/yourusername/dotfiles.git ~/dev/dotfiles
    ```
 
 2. Run the setup script:
    ```bash
-   cd ~/dev/home
+   cd ~/dev/dotfiles
    ./scripts/setup
    ```
 
@@ -37,7 +37,7 @@ This repository contains cross-platform configuration for macOS and Linux:
 If something is broken or you want a fresh start, run the reset script:
 
 ```bash
-cd ~/dev/home
+cd ~/dev/dotfiles
 ./scripts/reset
 ```
 
@@ -53,7 +53,7 @@ The reset script takes a "nuclear" approach - it deletes and recreates everythin
 Scripts auto-detect the repo path, but you can override it:
 
 ```bash
-export REPO_DIR=/path/to/your/home
+export REPO_DIR=/path/to/your/dotfiles
 cd $REPO_DIR
 ./scripts/setup
 ```
@@ -69,7 +69,7 @@ cd $REPO_DIR
 [Learn more](terminal/README.md)
 
 ### Shell Configuration
-- Modular ZSH configuration (edit `~/dev/home/shell/` directly)
+- Modular ZSH configuration (edit `~/dev/dotfiles/shell/` directly)
 - `~/.zshrc` acts as loader—tools can add lines without breaking config
 - Lazy loading for better startup time
 - Total startup time tracking (including tool-added lines)

--- a/direnv/README.md
+++ b/direnv/README.md
@@ -15,7 +15,7 @@ Running `./setup` will:
 2. Create the direnv config directory (`~/.config/direnv`)
 3. Symlink the direnv configuration:
    ```
-   ~/.config/direnv/direnvrc → ~/dev/home/direnv/direnvrc
+   ~/.config/direnv/direnvrc → ~/dev/dotfiles/direnv/direnvrc
    ```
 
 Changes to `direnvrc` in this repo are immediately reflected.
@@ -31,7 +31,7 @@ Changes to `direnvrc` in this repo are immediately reflected.
 
 2. Copy the example template:
    ```bash
-   cp ~/dev/home/direnv/.envrc.uv.example .envrc
+   cp ~/dev/dotfiles/direnv/.envrc.uv.example .envrc
    ```
 
 3. Allow direnv to activate:

--- a/git/.gitconfig.shared
+++ b/git/.gitconfig.shared
@@ -2,7 +2,7 @@
 # This file contains universal git settings that should be consistent across all machines.
 # Include this in your ~/.gitconfig with:
 #   [include]
-#       path = ~/dev/home/git/.gitconfig.shared
+#       path = ~/dev/dotfiles/git/.gitconfig.shared
 
 [core]
     whitespace = trailing-space,space-before-tab

--- a/git/README.md
+++ b/git/README.md
@@ -15,7 +15,7 @@ This setup separates git configuration into two layers:
 Your local `~/.gitconfig` includes the shared config using:
 ```ini
 [include]
-    path = ~/dev/home/git/.gitconfig.shared
+    path = ~/dev/dotfiles/git/.gitconfig.shared
 ```
 
 ## Features
@@ -61,11 +61,11 @@ Running `./setup` will:
 1. Verify Git is installed
 2. Symlink the global gitignore:
    ```
-   ~/.gitignore_global → ~/dev/home/git/.gitignore_global
+   ~/.gitignore_global → ~/dev/dotfiles/git/.gitignore_global
    ```
 3. Configure Git to include the shared configuration:
    ```
-   git config --global include.path "~/dev/home/git/.gitconfig.shared"
+   git config --global include.path "~/dev/dotfiles/git/.gitconfig.shared"
    ```
 
 Changes to `.gitignore_global` or `.gitconfig.shared` in this repo are immediately reflected across all Git operations.
@@ -82,7 +82,7 @@ When verifying git configuration, note the difference between `git config --glob
 **For testing/verification:**
 ```bash
 # Check include.path is set in global config
-git config --global include.path  # Returns: ~/dev/home/git/.gitconfig.shared
+git config --global include.path  # Returns: ~/dev/dotfiles/git/.gitconfig.shared
 
 # Check settings from shared config (must omit --global to read included files)
 git config push.autosetupremote   # Returns: true (from .gitconfig.shared)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "home"
+name = "dotfiles"
 version = "0.1.0"
 description = "Development environment and AI CLI tools configuration"
 requires-python = ">=3.12"

--- a/shell/.zsh/aliases.zsh
+++ b/shell/.zsh/aliases.zsh
@@ -10,5 +10,5 @@ alias systemctl="sudo systemctl"
 
 # Custom aliases
 alias reload="exec zsh"
-alias cdm="cd ~/dev/home/"
+alias cdm="cd ~/dev/dotfiles/"
 alias dps='docker ps -a --format="table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"'

--- a/shell/README.md
+++ b/shell/README.md
@@ -6,11 +6,11 @@ Cross-platform ZSH shell configuration for macOS and Linux.
 
 ```
 ~/.zshrc                          # Loader file (tools add lines here)
-  └── sources ~/dev/home/shell/.zshrc
+  └── sources ~/dev/dotfiles/shell/.zshrc
         └── sources .zsh/*.zsh    # Modular configs
 ```
 
-**Key benefit:** Tools can add lines to `~/.zshrc` without breaking your setup. Your customizations live in `~/dev/home/shell/` and are always sourced.
+**Key benefit:** Tools can add lines to `~/.zshrc` without breaking your setup. Your customizations live in `~/dev/dotfiles/shell/` and are always sourced.
 
 ## Directory Structure
 
@@ -86,7 +86,7 @@ _shellperf_tag "tagname" "After the operation"
 Running `./setup` will:
 1. Symlink `.zprofile`:
    ```
-   ~/.zprofile → ~/dev/home/shell/.zprofile
+   ~/.zprofile → ~/dev/dotfiles/shell/.zprofile
    ```
 2. Create/update `~/.zshrc` to source our config (preserving any existing tool additions)
 3. Prompt you to set ZSH as your default shell (if not already)
@@ -100,7 +100,7 @@ chsh -s $(which zsh)
 
 ### Customization
 
-Edit files directly in `~/dev/home/shell/`:
+Edit files directly in `~/dev/dotfiles/shell/`:
 - Add aliases in `.zsh/aliases.zsh`
 - Add work configs in `.zsh/work.zsh`
 - Create new `.zsh/*.zsh` files (auto-sourced)

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -58,7 +58,7 @@ Running `./setup` will:
 
 The entire Ghostty directory is symlinked from this repo:
 ```
-~/.config/ghostty/ → ~/dev/home/terminal/ghostty/
+~/.config/ghostty/ → ~/dev/dotfiles/terminal/ghostty/
 ```
 
 This ensures relative paths in the config (like `config-file = colours/eva01`) resolve correctly. Changes to the config in this repo are immediately reflected.


### PR DESCRIPTION
### Why are you making these changes?

The repo name "home" clashes with the "nexus" homelab project. Renaming to "dotfiles" aligns with GitHub's first-class dotfiles support and industry convention. All `~/dev/home` path references updated to `~/dev/dotfiles` across docs, aliases, git config, CI, and pyproject.toml.

Depends on #20 (--keep flag) so the rename migration can use `inv reset --keep` to preserve tool-installed zshrc content.

### How was this tested?

All checks pass (format, lint, typecheck, 74 tests). Paths that auto-resolve (tasks.py `REPO_DIR`, setup scripts, symlinks) confirmed unchanged.