### PR TITLE
Add cdd alias and track ccstatusline config

### DIFF
--- a/ai/modules/ccstatusline/settings.json
+++ b/ai/modules/ccstatusline/settings.json
@@ -1,0 +1,76 @@
+{
+  "version": 3,
+  "lines": [
+    [
+      {
+        "id": "1",
+        "type": "model",
+        "color": "brightWhite"
+      },
+      {
+        "id": "2",
+        "type": "separator"
+      },
+      {
+        "id": "3",
+        "type": "context-percentage",
+        "color": "brightBlue"
+      },
+      {
+        "id": "4",
+        "type": "separator"
+      },
+      {
+        "id": "833c9add-8ecb-4ca8-a3ed-f5f4bae1652b",
+        "type": "session-cost",
+        "color": "brightRed"
+      },
+      {
+        "id": "48748fb3-548d-494b-93ad-dd5059731eb0",
+        "type": "separator"
+      }
+    ],
+    [
+      {
+        "id": "c3790a11-9a1e-4686-928b-cd9c21c8e236",
+        "type": "git-branch",
+        "color": "brightMagenta"
+      },
+      {
+        "id": "f6367032-8179-47ed-a23c-7da7d0c634b8",
+        "type": "separator"
+      },
+      {
+        "id": "045a38a7-b81f-47ef-a5f3-8534ddc82efa",
+        "type": "git-changes"
+      },
+      {
+        "id": "7b3f8186-1506-4dd6-8859-722388604773",
+        "type": "separator"
+      },
+      {
+        "id": "7df5d224-bd34-4751-803b-6edd26688ca5",
+        "type": "block-timer",
+        "color": "green"
+      }
+    ],
+    []
+  ],
+  "flexMode": "full-minus-40",
+  "compactThreshold": 60,
+  "colorLevel": 2,
+  "inheritSeparatorColors": false,
+  "globalBold": false,
+  "powerline": {
+    "enabled": false,
+    "separators": [
+      ""
+    ],
+    "separatorInvertBackground": [
+      false
+    ],
+    "startCaps": [],
+    "endCaps": [],
+    "autoAlign": false
+  }
+}

--- a/ai/tools.json
+++ b/ai/tools.json
@@ -47,6 +47,14 @@
       "symlinks": [],
       "skills_symlink": {"source": "skills", "target": "skills"}
     },
+    "ccstatusline": {
+      "name": "ccstatusline",
+      "config_dir": "~/.config/ccstatusline",
+      "tool_dir": "modules/ccstatusline",
+      "symlinks": [
+        {"source": "settings.json", "target": "settings.json"}
+      ]
+    },
     "vscode": {
       "name": "VS Code",
       "config_dir": "~/Library/Application Support/Code/User",

--- a/shell/.zsh/aliases.zsh
+++ b/shell/.zsh/aliases.zsh
@@ -11,4 +11,5 @@ alias systemctl="sudo systemctl"
 # Custom aliases
 alias reload="exec zsh"
 alias cdm="cd ~/dev/dotfiles/"
+alias cdd="cd ~/dev/docs/"
 alias dps='docker ps -a --format="table {{.ID}}\t{{.Image}}\t{{.Names}}\t{{.Status}}\t{{.Ports}}"'


### PR DESCRIPTION
### Why are you making these changes?

Add `cdd` shell alias for quick navigation to `~/dev/docs/`. Track ccstatusline settings in the dotfiles repo so the status line layout stays consistent across machines — previously this config lived only in `~/.config/ccstatusline/` and wasn't synced.

### How was this tested?

Verified symlink points correctly from `~/.config/ccstatusline/settings.json` to the repo copy.