### PR TITLE
Debloat READMEs across the repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ A modular development environment configuration focusing on Python, Node.js, and
 
 ## Overview
 
-This repository contains cross-platform configuration for macOS and Linux:
+Cross-platform configuration for macOS and Linux:
 
-- 🐚 Shell (ZSH) configuration with performance optimizations
-- 🐍 Python environment management (uv, venv, poetry)
-- 📦 Node.js version management (fnm + pnpm)
-- 🔧 Development tools (direnv, starship)
-- 🎨 Terminal customization (Ghostty, iTerm2)
+- Shell (ZSH) configuration with performance optimizations
+- Python environment management (uv, venv, poetry)
+- Node.js version management (fnm + pnpm)
+- Development tools (direnv, starship)
+- Terminal customization (Ghostty, iTerm2)
 
 ## Quick Start
 
@@ -34,19 +34,7 @@ This repository contains cross-platform configuration for macOS and Linux:
 
 ## Resetting a Broken Setup
 
-If something is broken or you want a fresh start, run the reset script:
-
-```bash
-cd ~/dev/dotfiles
-./scripts/reset
-```
-
-This will:
-1. Remove and recreate all config symlinks
-2. Reinstall any missing tools
-3. Reset shell configuration (backs up existing `.zshrc`)
-
-The reset script takes a "nuclear" approach - it deletes and recreates everything to ensure a clean state.
+If something is broken or you want a fresh start, run `./scripts/reset`. This removes and recreates all config symlinks, reinstalls missing tools, and resets shell configuration (backing up existing `.zshrc`).
 
 ## Custom Installation Path
 
@@ -59,72 +47,18 @@ cd $REPO_DIR
 ```
 
 ## Components
-### Terminal Setup
-- Fast python package management with uv
-- Node.js version management with fnm + pnpm
-- Custom prompt with starship
-- Ghostty terminal emulator with custom color scheme
-- iTerm2 color schemes and profiles (macOS)
 
-[Learn more](terminal/README.md)
-
-### Shell Configuration
-- Modular ZSH configuration (edit `~/dev/dotfiles/shell/` directly)
-- `~/.zshrc` acts as loader—tools can add lines without breaking config
-- Lazy loading for better startup time
-- Total startup time tracking (including tool-added lines)
-
-[Learn more](shell/README.md)
-
-### Python Development
-- Multiple python environment management options:
-  - uv (recommended)
-  - venv
-  - poetry
-- Automatic environment activation with direnv
-- Project scaffolding with `pyinit`
-
-[Learn more](direnv/README.md)
-
-### Git Configuration
-- Global gitignore settings
-- Common development files ignored
-
-[Learn more](git/README.md)
-
-## Features
-### Performance Optimizations
-- Lazy loading of heavy commands
-- Completion caching
-- Command evaluation caching
-- Shell startup profiling
-
-### Development Workflow
-- Automatic Python virtual environment activation
-- Node.js version switching per project
-- Custom terminal prompt with git status
-- Docker container status in prompt
+- **[Terminal](terminal/README.md)**: Ghostty/iTerm2 config, starship prompt, uv, fnm + pnpm
+- **[Shell](shell/README.md)**: Modular ZSH configuration with lazy loading and startup profiling
+- **[Python](direnv/README.md)**: Environment management (uv, venv, poetry) with direnv auto-activation and `pyinit` scaffolding
+- **[Git](git/README.md)**: Global gitignore, shared settings, machine-specific overrides
 
 ## Supported Platforms
 
-This setup is tested and fully supported on:
+- **macOS** (Intel and Apple Silicon) - requires Homebrew and Git
+- **Linux** (Debian/Ubuntu) - requires Git and sudo access
 
-- **macOS** (Intel and Apple Silicon)
-- **Linux** (Debian/Ubuntu)
-
-Other Linux distributions may work but are not officially supported.
-
-### Requirements
-
-**macOS:**
-- Homebrew (installed automatically if missing)
-- Git
-- Zsh (default on macOS)
-
-**Linux (Debian/Ubuntu):**
-- Git
-- Zsh (installed automatically if missing)
-- sudo access for package installation
+Zsh and Homebrew are installed automatically if missing.
 
 ## Customization
 
@@ -145,23 +79,4 @@ All configuration files are symlinked, so changes are immediately reflected with
 
 ## Testing
 
-This repository includes automated testing via GitHub Actions. The test workflow:
-
-- Runs on every push and pull request
-- Tests on both macOS and Ubuntu runners
-- Verifies all setup scripts run without errors
-- Validates that all configuration files are created
-- Confirms all tools are installed and accessible
-- Checks git configuration is correct
-- Tests setup idempotency (can be run multiple times)
-
-View test results in the "Actions" tab of your GitHub repository.
-
-## Troubleshooting
-
-### Shell Performance
-Use the built-in profiling tool to measure startup time:
-
-```bash
-shellperf
-```
+Automated tests run via GitHub Actions on every push and PR, verifying setup scripts, config files, tool installation, and idempotency on both macOS and Ubuntu.

--- a/git/README.md
+++ b/git/README.md
@@ -7,45 +7,25 @@ This directory contains global Git configuration:
 
 ## Architecture
 
-This setup separates git configuration into two layers:
+Git configuration is split into two layers:
 
-1. **Shared Configuration** (`.gitconfig.shared`): Version-controlled settings that should be consistent across all machines
+1. **Shared Configuration** (`.gitconfig.shared`): Version-controlled settings consistent across all machines
 2. **Local Configuration** (`~/.gitconfig`): Machine-specific settings like user info, credentials, and OS-specific helpers
 
-Your local `~/.gitconfig` includes the shared config using:
-```ini
-[include]
-    path = ~/dev/dotfiles/git/.gitconfig.shared
-```
+The local config includes the shared config via `[include] path = ~/dev/dotfiles/git/.gitconfig.shared`.
 
 ## Features
 
 ### Global Gitignore
 
-The global gitignore automatically excludes:
-- System files (`.DS_Store`, `Thumbs.db`)
-- Editor and IDE directories (`.vscode/`, `.idea/`)
-- Environment files (`.envrc`, `.env`)
-- Python artifacts (`__pycache__/`, `*.pyc`)
-- Node.js files (`node_modules/`)
+Excludes system files, editor/IDE directories, environment files, Python artifacts, and `node_modules/`.
 
 ### Shared Git Settings
 
-The `.gitconfig.shared` file includes:
-
-**Workflow preferences:**
-- **Auto-setup remote**: Automatically sets up remote tracking when pushing new branches (`push.autoSetupRemote`)
-- **Auto-prune**: Removes stale remote-tracking branches on fetch/pull (`fetch.prune`)
+- **Auto-setup remote**: Automatically sets up remote tracking when pushing new branches
+- **Auto-prune**: Removes stale remote-tracking branches on fetch/pull
 - **SSH for GitHub**: Rewrites HTTPS GitHub URLs to SSH
-
-**Display preferences:**
-- Whitespace handling rules
-- Mnemonic prefixes in diffs
-- Merge statistics
-
-**Aliases:**
-- `git com`: Checkout main or master branch
-- `git prune-branches`: Delete local branches whose upstream has been removed
+- **Aliases**: `git com` (checkout main/master), `git prune-branches` (delete merged local branches)
 
 ### Machine-Specific Settings
 
@@ -57,36 +37,4 @@ Keep these in your local `~/.gitconfig` (not version controlled):
 
 ## Setup
 
-Running `./setup` will:
-1. Verify Git is installed
-2. Symlink the global gitignore:
-   ```
-   ~/.gitignore_global → ~/dev/dotfiles/git/.gitignore_global
-   ```
-3. Configure Git to include the shared configuration:
-   ```
-   git config --global include.path "~/dev/dotfiles/git/.gitconfig.shared"
-   ```
-
-Changes to `.gitignore_global` or `.gitconfig.shared` in this repo are immediately reflected across all Git operations.
-
-## Technical Notes
-
-### Reading Git Config Values
-
-When verifying git configuration, note the difference between `git config --global` and `git config`:
-
-- `git config --global <key>` - Reads **only** from `~/.gitconfig` (does not include files)
-- `git config <key>` - Reads from **all sources** including `~/.gitconfig`, included files like `.gitconfig.shared`, local repo config, and system config
-
-**For testing/verification:**
-```bash
-# Check include.path is set in global config
-git config --global include.path  # Returns: ~/dev/dotfiles/git/.gitconfig.shared
-
-# Check settings from shared config (must omit --global to read included files)
-git config push.autosetupremote   # Returns: true (from .gitconfig.shared)
-git config alias.prune-branches   # Returns: <alias definition>
-```
-
-This is why CI tests use `git config` without `--global` when verifying settings from `.gitconfig.shared` - it tests what users actually experience when running git commands.
+Running `./setup` symlinks the global gitignore to `~/.gitignore_global` and configures Git to include `.gitconfig.shared`. Changes to either file are immediately reflected.

--- a/shell/README.md
+++ b/shell/README.md
@@ -45,53 +45,11 @@ Cross-platform ZSH shell configuration for macOS and Linux.
 
 ### Shell Performance Profiling
 
-The `shellperf` command provides detailed timing analysis of shell startup:
-
-```bash
-shellperf
-```
-
-Output example:
-```
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Shell Startup Performance Report
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-
-[base] 45ms
-  └─ Start base configuration: 2ms
-  └─ Loaded base configs: 30ms
-  └─ Loading Starship prompt: 8ms
-  └─ Loaded Starship prompt: 5ms
-
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-Config load time: 45ms
-Total startup time: 52ms (captured at first prompt)
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-```
-
-The "Total startup time" includes everything in `~/.zshrc`, including any tool-added lines.
-
-**Adding custom timing tags:**
-
-In any `.zsh` file, use `_shellperf_tag` to mark timing points:
-
-```bash
-_shellperf_tag "tagname" "Description of what you're measuring"
-# ... code to measure ...
-_shellperf_tag "tagname" "After the operation"
-```
+The `shellperf` command provides detailed timing analysis of shell startup, showing per-section load times and total startup time (including any tool-added lines in `~/.zshrc`).
 
 ### Configuration
 
-Running `./setup` will:
-1. Symlink `.zprofile`:
-   ```
-   ~/.zprofile → ~/dev/dotfiles/shell/.zprofile
-   ```
-2. Create/update `~/.zshrc` to source our config (preserving any existing tool additions)
-3. Prompt you to set ZSH as your default shell (if not already)
-
-Changes to `.zprofile` in this repo are immediately reflected.
+Running `./setup` symlinks `.zprofile` to `~/.zprofile` and creates/updates `~/.zshrc` to source the dotfiles config (preserving any existing tool additions).
 
 To change your default shell to zsh:
 ```bash

--- a/terminal/README.md
+++ b/terminal/README.md
@@ -14,7 +14,7 @@ Cross-platform terminal configuration and tools setup for macOS and Linux.
 
 ## Installed Tools
 
-Running `./setup` installs the following tools:
+Running `./setup` installs and configures the following:
 
 - **uv**: Fast Python package installer and virtual environment manager
 - **fnm**: Fast Node.js version manager (auto-switches per project)
@@ -25,26 +25,6 @@ Running `./setup` installs the following tools:
 
 PATH configuration for these tools is handled in `shell/.zsh/base.zsh`.
 
-### Installation Methods
-
-| Tool | macOS | Linux |
-|------|-------|-------|
-| uv | Official installer | Official installer |
-| fnm | Homebrew | Official installer |
-| pnpm | Official installer | Official installer |
-| starship | Homebrew | Official installer |
-| zsh-completions | Homebrew | System package manager |
-| Ghostty | Homebrew Cask | Debian repo / AUR |
-
-## Setup
-
-Running `./setup` will:
-1. Detect your platform (macOS or Linux)
-2. Install all required tools using the appropriate method
-3. Symlink Ghostty directory to `~/.config/ghostty/`
-4. Symlink Starship config to `~/.config/starship.toml`
-5. Provide status feedback for each installation
-
 ## Ghostty Terminal
 
 [Ghostty](https://ghostty.org) is a modern, GPU-accelerated terminal emulator. The configuration includes:
@@ -53,15 +33,6 @@ Running `./setup` will:
 - **Color scheme**: Eva01-inspired dark theme with purple/green accents (switchable to eva02)
 - **Cursor**: Non-blinking block cursor
 - **Scrollback**: 1000 lines
-
-### Configuration Location
-
-The entire Ghostty directory is symlinked from this repo:
-```
-~/.config/ghostty/ → ~/dev/dotfiles/terminal/ghostty/
-```
-
-This ensures relative paths in the config (like `config-file = colours/eva01`) resolve correctly. Changes to the config in this repo are immediately reflected.
 
 ### Keybindings
 
@@ -75,41 +46,20 @@ This ensures relative paths in the config (like `config-file = colours/eva01`) r
 | `Ctrl+Backspace` | Delete word backward (alternative) |
 | `Shift+Enter` | Newline without executing (for Claude Code, etc.) |
 
-#### Shift+Enter Compatibility
-
-Ghostty uses a modern keyboard protocol ("fixterms") that sends disambiguated key sequences. However, most applications (including Claude Code) expect legacy escape sequences. By default, Shift+Enter sends `[27;2;13~` which apps don't recognize.
-
-The config explicitly binds Shift+Enter to send `\x1b\r` (ESC + carriage return), matching iTerm2's behavior. This is harmless in regular shells (acts like Enter) and enables proper newline insertion in apps like Claude Code.
-
-See [ghostty-org/ghostty#1850](https://github.com/ghostty-org/ghostty/issues/1850) for details.
-
-### Shell Integration
-
-Ghostty shell integration is manually sourced in the zsh loader (`.zshrc.loader`) to ensure it works after `exec zsh` (the `reload` alias). This enables:
-- Proper tab title updates
-- No false "running process" warnings when closing tabs
-- Working directory tracking
-
-### Linux Installation
-
-On Debian/Ubuntu, Ghostty is installed automatically via the community repository at `debian.griffo.io`.
-
-Other Linux distributions are not officially supported - see [Ghostty docs](https://ghostty.org/docs/install/linux) for manual installation.
-
 ## iTerm2 (macOS Only)
 
 ### Importing Color Schemes
 
 1. Open iTerm2
-2. Go to Preferences → Profiles → Colors
-3. Click Color Presets → Import
+2. Go to Preferences > Profiles > Colors
+3. Click Color Presets > Import
 4. Select a color scheme from `iterm2/colours/` (e.g., `eva01.itermcolors`)
 
 ### Importing Custom Profile
 
 1. Open iTerm2
-2. Go to Preferences → Profiles
-3. Click Other Actions → Import JSON Profiles
+2. Go to Preferences > Profiles
+3. Click Other Actions > Import JSON Profiles
 4. Select `iterm2/Custom.json`
 
 ## Starship Configuration
@@ -121,17 +71,3 @@ The custom Starship prompt is configured in `starship.toml`. It includes:
 - Language version indicators (Python, Node.js, etc.)
 
 The configuration is symlinked to `~/.config/starship.toml`, which is the default location Starship looks for.
-
-## Node.js with pnpm
-
-fnm automatically installs and switches Node versions per-project when a `.node-version` or `.nvmrc` file is present.
-
-```bash
-# Install Node for a project
-cd my-project
-echo "20" > .node-version  # fnm will auto-install on cd
-
-# Or manually install a version
-fnm install 20
-fnm use 20
-```


### PR DESCRIPTION
### Why are you making these changes?

The READMEs were verbose with redundant sections, implementation details, and overlapping content. Trimmed all 4 to essential reference material:

- `README.md`: 168 → 82 lines — merged Components/Features, condensed Reset/Platforms/Testing
- `terminal/README.md`: 138 → 73 lines — removed Installation Methods table, Shift+Enter deep-dive, Shell Integration, Linux Installation, Node.js sections
- `git/README.md`: 93 → 40 lines — removed Technical Notes section, condensed Features/Architecture/Setup
- `shell/README.md`: 109 → 66 lines — removed shellperf example output, custom timing tags subsection

### How was this tested?

Read each file after editing to confirm readability and flow. Verified line reductions with `git diff --stat`.