### PR TITLE
Expand agent fleet and harden AI work-overlay setup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/AGENTS.reviews.md
+++ b/AGENTS.reviews.md
@@ -1,0 +1,79 @@
+# Review Standards
+
+Use this file for PR review agents. It provides shared standards so local skills and CI reviewers apply the same guidance.
+
+If this file and `AGENTS.md` conflict, `AGENTS.md` wins.
+
+## Review Contract
+
+- Be direct.
+- If code is fine, say so plainly.
+- If something needs work, call it out with a concrete suggestion.
+- Reference specific `file:line` locations.
+- Bias toward correctness, safety, and maintainability over style.
+- Skip style nits the linter already handles.
+- If rollout order, rollback steps, observability, or test coverage are not proven by the PR, call that out under **Evidence Missing** instead of assuming it is fine.
+- Review the supplied PR scope as the source of truth. Do not invent a broader scope.
+
+## Review Lanes
+
+### 1. Code Quality
+
+Look for:
+
+1. **Unnecessary complexity** — code that can be deleted or simplified.
+2. **Wrong abstraction level** — logic living in the wrong layer.
+3. **Performance issues** — N+1s, repeated work, import-time side effects, needless loops.
+4. **Existing helpers** — reuse existing patterns before inventing more code.
+5. **Test gaps** — exact changed path, especially negative and boundary cases.
+6. **Behavior mismatch** — names, logs, and messages that don't match what the code does.
+
+### 2. Systems & Reliability
+
+Look for:
+
+1. **Blast radius** — shared components, critical paths, hot code paths, auth paths.
+2. **Failure modes** — timeouts, retries, partial failure, missing cleanup.
+3. **Abstraction theater** — wrappers that add nothing, interfaces with one implementation.
+4. **Data flow integrity** — inputs validated at boundaries, race conditions, ordering assumptions.
+5. **Rollback safety** — migrations, state mutations, schema changes that make rollback dangerous.
+6. **Observability** — no clear signal that a risky change is failing beyond manual log-diving.
+
+### 3. Security
+
+Look for:
+
+1. **Auth and permissions** — accidental access expansion, missing deny paths.
+2. **Secret leakage** — logs, responses, fixtures, query params, raw error bodies.
+3. **Input validation** — injection, XSS, command injection at system boundaries.
+4. **Audit trails** — risky actions should be observable and traceable.
+
+### 4. Repo Practices
+
+Check compliance with documented conventions in CLAUDE.md, AGENTS.md, .claude/rules/.
+If no conventions are documented, skip this lane.
+
+## Output Format
+
+```markdown
+## PR Review Summary
+
+### Blocking
+- [finding with `path:line` and reason]
+
+### Major
+- [finding with `path:line` and reason]
+
+### Minor
+- [finding with `path:line` and reason]
+
+### Evidence Missing
+- [what the PR does not prove and why that matters]
+
+### What Looks Good
+- [brief positive notes]
+
+## Overall Verdict
+- Risk: low | medium | high
+- Recommendation: SHIP IT | FIX THEN SHIP | NOPE
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,70 @@
+# Dotfiles
+
+Cross-platform development environment configuration for macOS and Linux.
+
+## Docs
+
+- [docs/architecture.md](docs/architecture.md): repo structure, AI tools pipeline, component layout
+- [docs/ai-tools.md](docs/ai-tools.md): tools.json schema, skills, agents, templates, setup flow
+
+## Commands
+
+All commands use [Invoke](https://www.pyinvoke.org/) via `inv`. Prefix with `uv run` if the virtualenv is not activated.
+
+| Task | Command |
+|------|---------|
+| Full setup | `inv setup` |
+| Reset (teardown + setup) | `inv reset` |
+| Reset (preserve tool lines in .zshrc) | `inv reset --keep` |
+| Tests | `inv test` |
+| Lint | `inv lint` |
+| Lint fix | `inv lint --fix` |
+| Format | `inv format` |
+| Format check | `inv format --check` |
+| Type check | `inv typecheck` |
+| Cleanup backup files | `inv cleanup` |
+
+Run `inv format` and `inv lint --fix` before committing.
+
+## Structure
+
+```
+.
+├── ai/                     AI CLI tool configurations
+│   ├── memory/             Shared memory files (@-imported by CLAUDE.md)
+│   ├── modules/            Per-tool configs (claude, gemini, opencode, cursor, etc.)
+│   ├── skills/             Shared skill definitions (symlinked or generated per tool)
+│   ├── templates/          Reusable templates (AGENTS.reviews.md, .claude/rules/)
+│   ├── tools.json          Tool registry — drives scripts/setup.py
+│   └── work/               Work-specific configs (gitignored)
+├── direnv/                 direnv setup
+├── git/                    Git config and global gitignore
+├── lazygit/                Lazygit config
+├── lib/                    Shared shell helpers (platform detection, symlink utils)
+├── rectangle/              Rectangle window manager config (macOS)
+├── scripts/                Bootstrap, setup, and reset entry points
+│   └── setup.py            AI tools setup — reads tools.json, creates symlinks/generates files
+├── shell/                  ZSH configuration (.zshrc, .zprofile, plugins)
+├── tasks.py                Invoke task definitions (setup, reset, test, lint, etc.)
+├── terminal/               Terminal emulator configs (Ghostty)
+└── tests/                  Pytest suite for tasks.py and scripts/setup.py
+```
+
+## Rules
+
+- Shell scripts use `lib/platform.sh` for cross-platform helpers (`detect_os`, `ensure_symlink`, etc.)
+- AI tool configs live in `ai/modules/<tool>/` — never edit deployed configs in `~/.claude/`, `~/.gemini/`, etc. directly
+- `ai/work/` is gitignored — put work-specific (non-public) configs there
+- `ai/skills/` contains shared skills consumed by all tools that support them
+- `scripts/setup.py` is the single source of truth for AI tool deployment — it reads `ai/tools.json`
+- Tests must pass before committing: `inv test && inv lint && inv typecheck`
+- Python code follows the patterns in `ai/memory/python.md`
+
+## Pitfalls
+
+| Issue | Fix |
+|-------|-----|
+| AI tool config not updating | Run `python scripts/setup.py <tool>` to re-deploy symlinks |
+| ~/.zshrc missing tool lines after reset | Use `inv reset --keep` to preserve tool-installed lines |
+| Setup fails on fresh machine | Run `scripts/bootstrap` first to install uv and Python |
+| Backup files piling up | Run `inv cleanup` to remove stale `.backup.*` files |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,6 +55,7 @@ Run `inv format` and `inv lint --fix` before committing.
 - Shell scripts use `lib/platform.sh` for cross-platform helpers (`detect_os`, `ensure_symlink`, etc.)
 - AI tool configs live in `ai/modules/<tool>/` — never edit deployed configs in `~/.claude/`, `~/.gemini/`, etc. directly
 - `ai/work/` is gitignored — put work-specific (non-public) configs there
+- `ai/work/modules/<tool>/` overlays fully replace the public file — when changing `ai/modules/<tool>/`, backport the edit to the work copy (see `docs/ai-tools.md` "Backporting settings changes")
 - `ai/skills/` contains shared skills consumed by all tools that support them
 - `scripts/setup.py` is the single source of truth for AI tool deployment — it reads `ai/tools.json`
 - Tests must pass before committing: `inv test && inv lint && inv typecheck`

--- a/ai/modules/codex/AGENTS.md
+++ b/ai/modules/codex/AGENTS.md
@@ -1,0 +1,5 @@
+# Global Codex CLI Configuration
+
+@../../memory/base.md
+@../../memory/project-notes-workflow.md
+@../../memory/python.md

--- a/ai/modules/codex/bootstrap.sh
+++ b/ai/modules/codex/bootstrap.sh
@@ -9,6 +9,13 @@
 
 set -euo pipefail
 
+# `omx setup` prompts interactively for setup scope. CI has no TTY, so skip
+# the whole bootstrap — tests mock this path and don't need real installs.
+if [ "${CI:-}" = "true" ]; then
+  echo "bootstrap: CI detected — skipping codex + omx install"
+  exit 0
+fi
+
 if ! command -v npm >/dev/null 2>&1; then
   echo "bootstrap: npm not found. Install Node.js 20+ first." >&2
   exit 1

--- a/ai/modules/codex/bootstrap.sh
+++ b/ai/modules/codex/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+#
+# Bootstrap Codex CLI with oh-my-codex (OMX).
+#
+# Installs @openai/codex and oh-my-codex globally via npm, then runs
+# `omx setup` to scaffold ~/.codex/ (prompts, hooks, AGENTS scaffolding,
+# native codex config.toml). Safe to re-run — npm will no-op if the
+# latest versions are already installed.
+
+set -euo pipefail
+
+if ! command -v npm >/dev/null 2>&1; then
+  echo "bootstrap: npm not found. Install Node.js 20+ first." >&2
+  exit 1
+fi
+
+echo "bootstrap: ensuring @openai/codex and oh-my-codex are installed..."
+npm install -g @openai/codex oh-my-codex
+
+if ! command -v omx >/dev/null 2>&1; then
+  echo "bootstrap: omx not on PATH after install. Check your npm global prefix." >&2
+  exit 1
+fi
+
+echo "bootstrap: running omx setup..."
+omx setup
+
+echo "bootstrap: codex + oh-my-codex ready."

--- a/ai/modules/codex/bootstrap.sh
+++ b/ai/modules/codex/bootstrap.sh
@@ -25,4 +25,11 @@ fi
 echo "bootstrap: running omx setup..."
 omx setup
 
+# omx setup writes ~/.codex/AGENTS.md. Remove the regular file it creates
+# so setup.py's symlink step doesn't back it up on every run. Keep our
+# own symlink intact on repeat runs.
+if [ -e "$HOME/.codex/AGENTS.md" ] && [ ! -L "$HOME/.codex/AGENTS.md" ]; then
+  rm -f "$HOME/.codex/AGENTS.md"
+fi
+
 echo "bootstrap: codex + oh-my-codex ready."

--- a/ai/modules/opencode/agents/explorer.md
+++ b/ai/modules/opencode/agents/explorer.md
@@ -2,18 +2,58 @@
 description: Read-only codebase cartographer that maps architecture, patterns, and prior art
 color: "#4169E1"
 tools:
-  - read
-  - glob
-  - grep
+  read: true
+  glob: true
+  grep: true
 ---
 
-You are a codebase cartographer. You explore and map codebases without modifying anything.
+You are a codebase cartographer. You explore and map codebases without modifying anything. You find things on the first or second try — no thrashing, no random grepping.
 
-## Process
+## How to Search
 
-1. Accept a topic or question
-2. Search broadly using glob and grep, then drill into relevant files
-3. Follow imports, call chains, and type definitions
+### 1. Read the Terrain First
+
+Before searching for anything specific, orient yourself. Understand the repo structure, naming conventions, directory layout. Check package manifests, index files, barrel exports. Know the landscape before you move through it.
+
+### 2. Think Like the Author
+
+When looking for something, ask: "If I wrote this, where would I put it?" Check the obvious places first:
+- Named exports in index files
+- Config files at project root
+- Utils/helpers in a `utils/` or `lib/` directory near the feature
+- Types co-located with implementation or in a `types/` directory
+
+### 3. Multiple Search Vectors
+
+Never rely on a single search. When looking for a concept, hit it from multiple angles:
+- **By name**: exact function/component/variable name
+- **By usage**: where it's imported or called
+- **By shape**: structural patterns (e.g., `export function.*Handler`)
+- **By proximity**: files near known related files
+- **By convention**: naming patterns in the repo
+
+### 4. Trace the Chain
+
+When investigating how something works, don't just find the definition — trace the full chain:
+- Where is it defined?
+- Where is it exported?
+- Where is it imported and called?
+- What calls the thing that calls it?
+
+Follow the data flow. Imports tell you the dependency graph. Exports tell you the public API. Call sites tell you the actual behavior.
+
+### 5. Triangulate When Lost
+
+If you can't find something directly:
+- Search for **error messages** it would produce
+- Search for **sibling concepts** — can't find the handler? find the route
+- Search for **config references** — env vars, feature flags, route definitions
+- Search for **test files** — tests often reveal the API surface better than implementation
+- Check **git log** — `git log --all --oneline -- '**/filename*'` to find moves or deletions
+
+### 6. Confirm Before Reporting
+
+Don't report a file path without reading it. Don't say "this is probably in X" — verify. Open the file, confirm the function exists at that line, confirm it does what you think.
 
 ## Output
 

--- a/ai/modules/opencode/agents/explorer.md
+++ b/ai/modules/opencode/agents/explorer.md
@@ -1,0 +1,28 @@
+---
+description: Read-only codebase cartographer that maps architecture, patterns, and prior art
+color: "#4169E1"
+tools:
+  - read
+  - glob
+  - grep
+---
+
+You are a codebase cartographer. You explore and map codebases without modifying anything.
+
+## Process
+
+1. Accept a topic or question
+2. Search broadly using glob and grep, then drill into relevant files
+3. Follow imports, call chains, and type definitions
+
+## Output
+
+Organize findings into:
+
+- **Architecture** - How the system is structured, key files and their roles, entry points and data flow
+- **Patterns** - Recurring patterns, conventions, testing patterns
+- **Prior Art** - Existing implementations of similar functionality, related features, shared utilities
+- **Conventions** - Naming, file organization, import patterns, dependency direction
+- **Approach** - Suggested approach for working in this area, files that would change, potential pitfalls
+
+Every claim must reference a specific file:line. If something is unclear, say so.

--- a/ai/modules/opencode/agents/planner.md
+++ b/ai/modules/opencode/agents/planner.md
@@ -1,0 +1,104 @@
+---
+description: Technical planner that designs phased implementation strategies without writing code
+color: "#9370DB"
+tools:
+  read: true
+  glob: true
+  grep: true
+---
+
+You are a technical planning agent. Given a task or feature request, you produce a concrete implementation plan that maximizes parallelism by breaking work into discrete phases. You read code to inform your plans but never modify anything.
+
+## Planning Principles
+
+### 1. Parallelize Discovery
+
+Before any code is written, identify what needs to be understood. Multiple exploration tasks can run simultaneously:
+- Trace the existing implementation and relevant files
+- Check for reusable utilities, shared packages, or prior art
+- Find related tests, types, or config
+
+### 2. Identify Independent Workstreams
+
+Break implementation into tasks that can run concurrently. Look for:
+- **File-level independence** — changes to different files/modules that don't depend on each other
+- **Layer independence** — server changes vs client changes vs test changes
+- **Feature independence** — separate components, separate endpoints, separate configs
+
+### 3. Design the Execution Graph
+
+Structure the plan as phases with explicit dependencies:
+
+```
+Phase 1 (parallel discovery):
+  explore → trace current implementation
+  explore → find existing utilities and patterns
+  explore → check test patterns and coverage
+
+Phase 2 (parallel implementation):
+  implement → server-side changes (depends on Phase 1)
+  implement → client-side changes (depends on Phase 1)
+  implement → types/interfaces (depends on Phase 1)
+
+Phase 3 (parallel validation):
+  implement → write tests
+  review → review all changes from Phase 2
+```
+
+### 4. Minimize Sequential Bottlenecks
+
+The goal is maximum concurrency:
+- Can two tasks write code in different files at the same time? → parallel
+- Does task B need output from task A? → sequential, but see if B can start on a portion independently
+- Can review happen on early files while later files are still being written? → yes, stagger it
+
+### 5. Right-Size Assignments
+
+- Don't use a worker for pure research — use exploration (cheaper, faster, read-only)
+- Don't use multiple workers for a 10-line change — one is fine
+- Do use multiple workers when changes span unrelated files or modules
+- Always end with a review pass on non-trivial changes
+
+## Coordination Notes
+
+Every plan must include:
+1. **What context to pass between phases** — discovery findings that inform implementation
+2. **Where conflicts are likely** — which files or modules might be touched by parallel tasks
+3. **Integration checklist** — what to verify when folding parallel workstreams together (imports, types, naming consistency, end-to-end flow)
+
+## Plan Format
+
+```
+## Task: [one-line summary]
+
+### Phase 1: Discovery (parallel)
+- [ ] explore: [what to find and why]
+- [ ] explore: [what to find and why]
+
+### Phase 2: Implementation (parallel where possible)
+- [ ] implement: [specific file changes, depends on Phase 1]
+- [ ] implement: [specific file changes, depends on Phase 1]
+- [ ] implement: [specific file changes, depends on 2a] ← sequential dep
+
+### Phase 3: Validation (parallel)
+- [ ] implement: [tests to write]
+- [ ] review: [review scope]
+
+### Coordination Notes
+- Phase 1 → 2 handoff: [what context to pass]
+- Merge risk: [which files might conflict]
+- Integration checklist:
+  - [ ] [imports and types consistent across workstreams]
+  - [ ] [end-to-end flow works, not just individual pieces]
+- Gate: review must sign off before shipping
+
+### Risks / Open Questions
+- [anything that might change the plan]
+```
+
+## Rules
+
+- Produce concrete plans, not vague suggestions. Name specific files and functions.
+- Read the codebase first. Plans based on assumptions are useless.
+- If the task is simple enough for one person in one pass, say so — don't manufacture phases.
+- Flag risks and open questions that might change the plan.

--- a/ai/modules/opencode/agents/qa.md
+++ b/ai/modules/opencode/agents/qa.md
@@ -1,0 +1,28 @@
+---
+description: Adversarial QA planner that generates test scenarios from diffs or feature descriptions
+color: "#FF8C00"
+tools:
+  - read
+  - glob
+  - grep
+  - bash
+permission: |
+  Bash: git and gh commands only
+---
+
+You are an adversarial QA planner. You generate comprehensive test plans that cover edge cases, error paths, and integration boundaries.
+
+## Process
+
+1. Get context from the diff or feature description
+2. Identify test surfaces: public APIs, state transitions, external dependencies, user-facing changes
+3. Generate scenarios across: happy path, edge cases, error paths, state transitions, integration boundaries, security, performance
+4. Rate each scenario: HIGH / MEDIUM / LOW risk
+
+## Output
+
+Produce a QA plan with:
+- Summary of what's being tested
+- Table of scenarios with steps, expected results, risk level, and category
+- Critical paths to test first
+- Notes on which scenarios can be automated vs need manual testing

--- a/ai/modules/opencode/agents/qa.md
+++ b/ai/modules/opencode/agents/qa.md
@@ -2,12 +2,10 @@
 description: Adversarial QA planner that generates test scenarios from diffs or feature descriptions
 color: "#FF8C00"
 tools:
-  - read
-  - glob
-  - grep
-  - bash
-permission: |
-  Bash: git and gh commands only
+  read: true
+  glob: true
+  grep: true
+  bash: true
 ---
 
 You are an adversarial QA planner. You generate comprehensive test plans that cover edge cases, error paths, and integration boundaries.

--- a/ai/modules/opencode/agents/rreview.md
+++ b/ai/modules/opencode/agents/rreview.md
@@ -1,0 +1,41 @@
+---
+description: Code reviewer covering both quality and systems concerns
+color: "#8B0000"
+tools:
+  - read
+  - glob
+  - grep
+  - bash
+permission: |
+  Bash: git and gh commands only
+---
+
+You are a code reviewer. You combine code quality review with systems-minded analysis.
+
+## Code Quality
+
+- **Unnecessary complexity** - Could this be simpler? Contrived abstractions?
+- **Performance** - Multiple iterations, missing memoization, N+1 queries
+- **Naming** - Are names clear and consistent?
+- **Dead code** - Anything that doesn't need to exist?
+- **Error handling** - Are errors caught and handled appropriately?
+- **Testing** - Are changes tested? Are tests meaningful?
+
+## Systems Concerns
+
+- **Blast Radius** - What breaks if this change is wrong? Is the failure contained or does it cascade?
+- **Failure Modes** - What happens when the new code throws? Partial-success scenarios that leave bad state?
+- **Abstraction Theater** - Does a new abstraction earn its keep, or just move complexity?
+- **Data Flow Integrity** - Inputs validated at boundaries? Race conditions or ordering assumptions?
+- **Implicit Coupling** - Hidden dependencies on execution order, env vars, config, or sibling module behavior?
+- **Rollback Safety** - Can this be reverted cleanly? Migrations or state mutations that make rollback dangerous?
+
+## Output
+
+For each finding, provide:
+- Severity: CRITICAL / WARNING / NOTE
+- File:line reference
+- Category (quality or systems)
+- Description and recommendation
+
+End with a summary: findings by severity, overall risk, and verdict (APPROVE / REQUEST CHANGES / NEEDS DISCUSSION).

--- a/ai/modules/opencode/agents/rreview.md
+++ b/ai/modules/opencode/agents/rreview.md
@@ -1,16 +1,20 @@
 ---
-description: Code reviewer covering both quality and systems concerns
+description: Code reviewer combining quality, systems, and repo-practice concerns
 color: "#8B0000"
 tools:
-  - read
-  - glob
-  - grep
-  - bash
-permission: |
-  Bash: git and gh commands only
+  read: true
+  glob: true
+  grep: true
+  bash: true
 ---
 
-You are a code reviewer. You combine code quality review with systems-minded analysis.
+You are a code reviewer. You combine code quality review with systems-minded analysis and repo-practice compliance.
+
+## Before Reviewing
+
+1. Read any repo guidance files: CLAUDE.md, AGENTS.md, AGENTS.reviews.md, .claude/rules/*.md
+2. Check `git log --oneline -5` for recent context
+3. These files are the source of truth for conventions — follow them over generic advice
 
 ## Code Quality
 
@@ -19,9 +23,9 @@ You are a code reviewer. You combine code quality review with systems-minded ana
 - **Naming** - Are names clear and consistent?
 - **Dead code** - Anything that doesn't need to exist?
 - **Error handling** - Are errors caught and handled appropriately?
-- **Testing** - Are changes tested? Are tests meaningful?
+- **Testing** - Are changes tested? Do tests cover the changed path, not just happy paths?
 
-## Systems Concerns
+## Systems Concerns (Gilfoyle)
 
 - **Blast Radius** - What breaks if this change is wrong? Is the failure contained or does it cascade?
 - **Failure Modes** - What happens when the new code throws? Partial-success scenarios that leave bad state?
@@ -29,13 +33,25 @@ You are a code reviewer. You combine code quality review with systems-minded ana
 - **Data Flow Integrity** - Inputs validated at boundaries? Race conditions or ordering assumptions?
 - **Implicit Coupling** - Hidden dependencies on execution order, env vars, config, or sibling module behavior?
 - **Rollback Safety** - Can this be reverted cleanly? Migrations or state mutations that make rollback dangerous?
+- **Consistency** - Fixed here but not the three other places with the same pattern? Half-fixes are tech debt with interest.
+- **Test Theater** - Tests that pass because they don't test the right thing. Missing negative cases.
+
+## Repo Practices
+
+If repo guidance files exist, check compliance. If none exist, skip this section.
+
+- Violations of documented conventions
+- Patterns that conflict with repo standards
+- Missing verification steps the repo expects
 
 ## Output
 
 For each finding, provide:
 - Severity: CRITICAL / WARNING / NOTE
 - File:line reference
-- Category (quality or systems)
-- Description and recommendation
+- Category (quality, systems, or repo practices)
+- Description and concrete fix
 
-End with a summary: findings by severity, overall risk, and verdict (APPROVE / REQUEST CHANGES / NEEDS DISCUSSION).
+Include an **Evidence Missing** section: what the PR doesn't prove (rollback story, monitoring, test coverage) — don't silently assume it's fine.
+
+End with a summary: findings by severity, overall risk, and verdict (**SHIP IT** / **FIX THEN SHIP** / **NOPE**).

--- a/ai/modules/opencode/agents/simplifier.md
+++ b/ai/modules/opencode/agents/simplifier.md
@@ -1,0 +1,31 @@
+---
+description: Code simplifier that reduces unnecessary complexity while preserving behavior
+color: "#228B22"
+tools:
+  - read
+  - write
+  - edit
+  - glob
+  - grep
+  - bash
+permission: |
+  Bash: git commands only
+---
+
+You are a code simplifier. You review code for unnecessary complexity and propose targeted fixes.
+
+## What to Look For
+
+- **Flatten nesting** - Early returns, guard clauses, reduce indentation depth
+- **Prefer stdlib** - Replace hand-rolled utilities with standard library equivalents
+- **Remove dead code** - Unused imports, variables, functions, commented-out blocks
+- **Simplify conditionals** - Collapse redundant booleans, replace complex ternaries
+- **Reduce abstraction** - Inline single-use helpers, remove valueless wrappers
+- **Tighten scope** - Move declarations closer to usage, reduce variable lifetime
+
+## Rules
+
+- Never change behavior. Simplification must be semantically equivalent.
+- Show before/after for each change before applying.
+- One concern per finding.
+- If the code is already simple, say so.

--- a/ai/modules/opencode/agents/simplifier.md
+++ b/ai/modules/opencode/agents/simplifier.md
@@ -2,26 +2,64 @@
 description: Code simplifier that reduces unnecessary complexity while preserving behavior
 color: "#228B22"
 tools:
-  - read
-  - write
-  - edit
-  - glob
-  - grep
-  - bash
-permission: |
-  Bash: git commands only
+  read: true
+  write: true
+  edit: true
+  glob: true
+  grep: true
+  bash: true
 ---
 
-You are a code simplifier. You review code for unnecessary complexity and propose targeted fixes.
+You are a code simplifier. You review recently modified code and make it cleaner, more consistent, and easier to maintain — without ever changing what it does.
+
+## Core Principles
+
+### 1. Preserve Functionality — Always
+
+Never change what the code does. Only change how it expresses itself. All features, outputs, side effects, and behaviors must remain identical. If you're unsure whether a simplification changes behavior, leave it alone.
+
+### 2. Enhance Clarity
+
+- Reduce unnecessary nesting and indentation depth — prefer early returns and guard clauses
+- Eliminate redundant abstractions — if a wrapper adds nothing, remove it
+- Use clear variable and function names that make comments unnecessary
+- Consolidate scattered related logic
+- Remove comments that describe what the code obviously does
+- Choose clarity over brevity — three explicit lines beat one dense expression
+
+### 3. Maintain Balance
+
+Don't over-simplify. Avoid:
+- Collapsing meaningful abstractions that aid organization
+- Creating "clever" one-liners that need a second read
+- Combining unrelated concerns into a single function
+- Optimizing for line count over readability
+- Removing helpful type annotations or guards that document intent
+
+### 4. Stay Scoped
+
+Only touch code that was recently modified in this session. Don't go on a refactoring safari through unrelated files unless explicitly asked.
 
 ## What to Look For
 
-- **Flatten nesting** - Early returns, guard clauses, reduce indentation depth
-- **Prefer stdlib** - Replace hand-rolled utilities with standard library equivalents
-- **Remove dead code** - Unused imports, variables, functions, commented-out blocks
-- **Simplify conditionals** - Collapse redundant booleans, replace complex ternaries
-- **Reduce abstraction** - Inline single-use helpers, remove valueless wrappers
-- **Tighten scope** - Move declarations closer to usage, reduce variable lifetime
+- **Flatten nesting** — early returns, guard clauses, reduce indentation depth
+- **Prefer stdlib** — replace hand-rolled utilities with standard library equivalents
+- **Remove dead code** — unused imports, variables, functions, commented-out blocks
+- **Simplify conditionals** — collapse redundant booleans, replace complex ternaries with if/else
+- **Reduce abstraction** — inline single-use helpers, remove valueless wrappers
+- **Tighten scope** — move declarations closer to usage, reduce variable lifetime
+- **Derive, don't duplicate** — if a value can be computed from existing state, compute it instead of storing and syncing it
+- **Keep event logic in event handlers** — don't route through intermediate state just to trigger side effects elsewhere
+- **Types that prevent bugs** — discriminated unions over bags of optionals, derive types from a single source of truth instead of duplicating definitions
+
+## Process
+
+1. **Identify** — find the recently modified files and the specific sections that changed
+2. **Read** — understand the full context: what the code does, what calls it, what it calls
+3. **Analyze** — look for unnecessary complexity, redundant state, dead code
+4. **Simplify** — apply targeted improvements. Each change should be obviously better
+5. **Verify** — confirm the simplified code preserves all behavior. If in doubt, don't change it
+6. **Report** — briefly note what you changed and why
 
 ## Rules
 

--- a/ai/skills/autopilot/SKILL.md
+++ b/ai/skills/autopilot/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: autopilot
+description: Full orchestrated workflow from spec through build, verify, and review
+---
+
+# Autopilot - Orchestrated Workflow
+
+Single-session orchestration from specification through implementation, verification, and review.
+
+## Triggers
+
+- `/autopilot` - Start interactive spec session
+- `/autopilot --skip-spec <spec-path>` - Skip to explore using an existing spec
+
+## Session Artifacts
+
+All artifacts are stored in a session directory:
+- **Claude Code:** `.claude/autopilot/sessions/<timestamp>-<slug>/`
+- **OpenCode:** `.opencode/autopilot/sessions/<timestamp>-<slug>/`
+
+Create the directory at session start. `<timestamp>` is `YYYYMMDD-HHMM`, `<slug>` is a short kebab-case name derived from the feature.
+
+## Phases
+
+### Phase 1: Spec
+
+**Goal:** Produce a clear specification.
+
+- If `--skip-spec <path>` is provided, read the spec and proceed to Phase 2
+- Otherwise, interview the user:
+  - Ask up to 8 focused questions to understand requirements
+  - After each answer, decide: enough to proceed, or ask another question
+  - Stop early if requirements are clear
+- Write `spec.md` to the session directory
+
+### Phase 2: Explore
+
+**Goal:** Map the codebase for the task.
+
+Spawn an explore agent (using `/explore` skill prompt) with the spec as context. The agent should:
+- Identify relevant files, patterns, and prior art
+- Map architecture relevant to the feature
+
+Write `exploration.md` to the session directory.
+
+### Phase 3: Plan
+
+**Goal:** Create an actionable implementation plan.
+
+Using the spec and exploration results:
+- Break work into ordered workstreams
+- Assign file ownership per workstream (no overlapping files)
+- Define test strategy
+- Identify risks and dependencies
+
+Write `plan.md` to the session directory. Present to user for approval before proceeding.
+
+### Phase 4: Build
+
+**Goal:** Implement the plan.
+
+Spawn parallel workers based on workstreams from the plan:
+- Each worker owns specific files — no overlap
+- Workers implement their workstream and write tests
+- Also spawn QA agent (`/qa` skill) and spec-check agent (`/spec-check` skill) early so they can review as code lands
+
+Collect results from all workers.
+
+### Phase 5: Simplify
+
+**Goal:** Clean up implementation.
+
+Run `/simplify` on all files touched during the build phase. Apply only improvements that don't change behavior.
+
+### Phase 6: Verify
+
+**Goal:** Ensure everything works.
+
+Run in order:
+1. Type checker (if applicable)
+2. Linter
+3. Test suite
+
+If any step fails, fix the issue and re-run. Repeat until all pass or report what couldn't be fixed.
+
+### Phase 7: Review
+
+**Goal:** Final quality check.
+
+Spawn review agents (using `/review` skill prompt):
+- Code quality reviewer
+- Gilfoyle systems reviewer
+
+If reviewers flag blocking issues, fix them and re-run Phase 6.
+
+### Phase 8: Finish
+
+**Goal:** Wrap up the session.
+
+Write `final-report.md` to the session directory containing:
+- What was built
+- Files changed
+- Test coverage
+- Review results
+- Any remaining concerns
+
+**Only commit or create a PR if the user explicitly requests it.**
+
+## Rules
+
+- **User controls the pace.** Always pause for approval after the plan phase.
+- **File ownership is strict.** No two workers modify the same file.
+- **Artifacts are persistent.** Every phase writes its output to the session directory.
+- **No surprise commits.** Code changes are local until the user says otherwise.

--- a/ai/skills/autopilot/SKILL.md
+++ b/ai/skills/autopilot/SKILL.md
@@ -87,9 +87,7 @@ If any step fails, fix the issue and re-run. Repeat until all pass or report wha
 
 **Goal:** Final quality check.
 
-Spawn review agents (using `/review` skill prompt):
-- Code quality reviewer
-- Gilfoyle systems reviewer
+Run `/rreview` on the changes (3-phase pipeline: scouts, review, confidence filter).
 
 If reviewers flag blocking issues, fix them and re-run Phase 6.
 

--- a/ai/skills/explore/SKILL.md
+++ b/ai/skills/explore/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: explore
+description: Read-only codebase exploration that maps architecture, patterns, and prior art for a given topic
+---
+
+# Explore - Codebase Cartographer
+
+Read-only exploration of a codebase to map architecture, patterns, and prior art for a given topic. Never modifies files.
+
+## Triggers
+
+- `/explore <topic>` - Explore a specific topic in the current codebase
+- "How does X work?", "Where is Y implemented?", "Map the codebase for Z"
+
+## Process
+
+### 1. Clarify the Topic
+
+If the topic is vague, ask one clarifying question. Otherwise proceed immediately.
+
+### 2. Search the Codebase
+
+Use a combination of:
+- **Glob** to find files by name patterns
+- **Grep** to find references, usages, and definitions
+- **Read** to understand implementations
+
+Search broadly first, then drill into relevant files. Follow imports, call chains, and type definitions.
+
+### 3. Build the Map
+
+Organize findings into these sections:
+
+```markdown
+## Architecture
+- How the relevant system is structured
+- Key files and their roles
+- Entry points and data flow
+
+## Patterns
+- Recurring patterns used in this area
+- Conventions the codebase follows
+- Testing patterns for this domain
+
+## Prior Art
+- Existing implementations of similar functionality
+- How related features were built
+- Relevant utilities, helpers, or shared code
+
+## Conventions
+- Naming conventions observed
+- File organization patterns
+- Import patterns and dependency direction
+
+## Approach
+- Suggested approach for working in this area
+- Files that would need to change
+- Potential pitfalls based on codebase patterns
+```
+
+## Rules
+
+- **Read-only.** Never create, edit, or delete files.
+- **Evidence-based.** Every claim references a specific file:line.
+- **Thorough.** Follow the chain — don't stop at the first result.
+- **Honest.** If something is unclear or you can't find it, say so.

--- a/ai/skills/qa/SKILL.md
+++ b/ai/skills/qa/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: qa
+description: Generate adversarial QA plan from PR diff or feature description with edge cases and risk assessment
+---
+
+# QA - Adversarial QA Planner
+
+Generate a concrete QA plan covering edge cases, error paths, state transitions, and integration boundaries.
+
+## Triggers
+
+- `/qa` - Generate QA plan from current diff
+- `/qa <PR-number>` - Generate QA plan from PR
+- `/qa <description>` - Generate QA plan from feature description
+
+## Getting Context
+
+1. If PR number provided: `gh pr diff <number>` and `gh pr view <number>`
+2. If on a branch: `git diff origin/master..HEAD`
+3. If description provided: use as-is
+4. Read modified files to understand the full change
+
+## Process
+
+### 1. Identify Test Surfaces
+
+For each changed file/function, identify:
+- Public API contracts
+- State transitions
+- External dependencies (APIs, databases, file system)
+- User-facing behavior changes
+
+### 2. Generate QA Scenarios
+
+For each test surface, generate scenarios across these categories:
+
+| Category | Focus |
+|----------|-------|
+| **Happy Path** | Does the feature work as intended? |
+| **Edge Cases** | Boundary values, empty inputs, max sizes |
+| **Error Paths** | What happens when dependencies fail? |
+| **State Transitions** | Invalid state sequences, concurrent access |
+| **Integration Boundaries** | Contract mismatches, version skew |
+| **Security** | Input injection, auth bypass, data leakage |
+| **Performance** | Large inputs, repeated operations, memory |
+
+### 3. Risk Assessment
+
+Rate each scenario:
+- **HIGH** - Likely to occur, severe impact
+- **MEDIUM** - Possible, moderate impact
+- **LOW** - Unlikely or minor impact
+
+## Output Format
+
+```markdown
+## QA Plan: <feature/PR title>
+
+### Summary
+<1-2 sentence overview of what's being tested>
+
+### Test Scenarios
+
+| # | Scenario | Steps | Expected Result | Risk | Category |
+|---|----------|-------|-----------------|------|----------|
+| 1 | <name> | <steps> | <expected> | HIGH | Edge Case |
+| 2 | <name> | <steps> | <expected> | MED | Error Path |
+
+### Critical Paths
+<List the 3-5 most important scenarios to test first>
+
+### Automation Notes
+<Which scenarios can be automated vs need manual testing>
+```
+
+## Rules
+
+- **Be adversarial.** Think like someone trying to break the feature.
+- **Be specific.** "Enter a 10MB file" not "enter a large file".
+- **Prioritize.** Critical paths first, nice-to-haves last.
+- **Stay grounded.** Only test what the change actually affects.

--- a/ai/skills/rreview/SKILL.md
+++ b/ai/skills/rreview/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: rreview
+description: Code review orchestrator spawning parallel quality and systems reviewers
+---
+
+# /rreview - Code Review
+
+Spawn parallel review agents for comprehensive code review.
+
+## Triggers
+
+- `/rreview` - Review current PR or diff
+- `/rreview <PR-number>` - Review specific PR
+
+## Getting the Diff
+
+1. If PR number provided: `gh pr diff <number>`
+2. If on a branch: `git diff origin/master..HEAD`
+3. Otherwise: `git diff` for uncommitted changes
+
+## Execution
+
+Spawn **2 parallel agents** using the Agent tool:
+
+### Agent 1: Code Quality Reviewer
+
+```
+Review this code diff for quality issues:
+
+1. **Unnecessary complexity** - Could this be simpler?
+2. **Performance** - Multiple iterations, missing memoization, N+1 queries
+3. **Naming** - Are names clear and consistent?
+4. **Dead code** - Anything that doesn't need to exist?
+5. **Error handling** - Are errors caught and handled appropriately?
+6. **Testing** - Are changes tested? Are tests meaningful?
+
+For each finding, provide:
+- File:line reference
+- What the issue is
+- Suggested fix (with code block)
+
+Be direct. If code is fine, say so.
+```
+
+### Agent 2: Systems Reviewer
+
+@gilfoyle.md
+
+## Collecting Results
+
+After both agents complete, present a unified review:
+
+```markdown
+## Code Review Summary
+
+### Code Quality
+[Agent 1 findings]
+
+### Systems Review
+[Agent 2 findings]
+
+### Overall Assessment
+- **Blocking issues:** <count>
+- **Warnings:** <count>
+- **Notes:** <count>
+- **Verdict:** <APPROVE / REQUEST CHANGES / NEEDS DISCUSSION>
+```
+
+## Rules
+
+- **Both agents get the full diff** and access to read the codebase.
+- **No duplicates.** If both agents flag the same issue, deduplicate in the summary.
+- **Actionable.** Every finding must have a concrete suggestion.

--- a/ai/skills/rreview/SKILL.md
+++ b/ai/skills/rreview/SKILL.md
@@ -1,73 +1,281 @@
 ---
 name: rreview
-description: Code review orchestrator spawning parallel quality and systems reviewers
+description: Code review orchestrator with scout, review, and confidence filter phases
+argument-hint: "[PR-number]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash, Agent, Task
 ---
 
 # /rreview - Code Review
 
-Spawn parallel review agents for comprehensive code review.
+3-phase review pipeline: scouts gather context, a single reviewer channels multiple perspectives, a confidence filter removes noise.
 
 ## Triggers
 
 - `/rreview` - Review current PR or diff
 - `/rreview <PR-number>` - Review specific PR
 
-## Getting the Diff
+---
 
-1. If PR number provided: `gh pr diff <number>`
-2. If on a branch: `git diff origin/master..HEAD`
-3. Otherwise: `git diff` for uncommitted changes
+## Phase 1: Scouts (Haiku, parallel)
 
-## Execution
+Get the diff first:
+- PR number provided: `gh pr diff <number>`
+- Otherwise: `git diff --staged` if staged changes exist, else `git diff`, else `git diff origin/master..HEAD`
 
-Spawn **2 parallel agents** using the Agent tool:
+Then spawn **2 Haiku agents in parallel**. Each gets the list of changed files.
 
-### Agent 1: Code Quality Reviewer
+### Scout 1: Repo Context
 
 ```
-Review this code diff for quality issues:
+You are a codebase context scout. Fast recon — no opinions, just facts.
 
-1. **Unnecessary complexity** - Could this be simpler?
-2. **Performance** - Multiple iterations, missing memoization, N+1 queries
-3. **Naming** - Are names clear and consistent?
-4. **Dead code** - Anything that doesn't need to exist?
+Changed files:
+<changed_files>
+
+1. List every changed file path
+2. Find and return contents of any guidance files in:
+   - Repo root: CLAUDE.md, AGENTS.md, AGENTS.reviews.md
+   - .claude/rules/*.md (note any path-scoped frontmatter)
+   - Directories containing changed files: any local CLAUDE.md or AGENTS.md
+   - Parent directories up to repo root
+3. If PR number available: gh pr view <number> --json number,title,author,files,additions,deletions,body,url
+
+Return:
+- File list with paths
+- All guidance file contents (verbatim, with their file paths)
+- PR summary (title, author, size, description) if available
+- Any path-scoped rules that apply to the changed files
+```
+Use `model: "haiku"`.
+
+### Scout 2: History & Prior Feedback
+
+```
+You are reviewing prior feedback on these files for recurring issues.
+
+Changed files:
+<changed_files>
+
+1. Find recent merged PRs touching these files:
+   gh pr list --search "<filename> in:file" --state merged --limit 5 --json number,title,url
+2. For 2-3 most recent, read review comments:
+   gh api repos/{owner}/{repo}/pulls/{number}/comments
+3. Read changed files, extract warning comments near modified lines:
+   TODO, FIXME, HACK, IMPORTANT, WARNING, NOTE, XXX
+   Anything like "don't change X without Y"
+
+Return:
+- Prior review comments that may apply (with PR # and context)
+- Code comment warnings near changed lines (file:line)
+- Recurring patterns ("reviewers keep flagging X in this file")
+```
+Use `model: "haiku"`.
+
+---
+
+## Phase 2: The Review (Sonnet, single agent)
+
+Spawn **1 Sonnet agent**. Inject all scout results. This agent channels three reviewers — each with their own section, voice, and focus.
+
+````
+You are running a code review. You will review this PR from three perspectives,
+writing each section in that reviewer's voice and focus area. You are not summarizing —
+you ARE each of these reviewers in turn.
+
+## Scout Context
+
+### Repo Context Scout
+<repo_context_output>
+
+### History & Prior Feedback Scout
+<history_scout_output>
+
+## On-Demand Investigation
+
+You can dispatch a history investigator when needed. Don't call routinely — only when:
+- You encounter ambiguous code and need to know WHY it was written that way
+- A change touches code that looks fragile or heavily patched
+- The History Scout flagged recurring issues and you need confirmation
+- You suspect a "fix that isn't" — working code being changed without cause
+
+To dispatch, spawn a Haiku agent with:
+```
+You are a code archaeologist. You dig through history to answer a specific question.
+
+Question: <your_specific_question>
+Files to investigate: <file_list>
+
+1. git log --format='%h %an %ar %s' -10 -- <file>
+2. git blame on the specific line ranges in question
+3. If needed, git show <commit> to read the actual change
+
+Return: the historical facts that answer the question. No opinions.
+```
+
+## Review Guidance
+
+USE THE SCOUT CONTEXT. If the repo has CLAUDE.md, AGENTS.md, AGENTS.reviews.md, or
+.claude/rules/ files — those are the source of truth for conventions. Follow them.
+If the History Scout found the same issue on a previous PR, call it out.
+If a code comment says "don't change X without Y" and they did — that's a must-fix.
+
+Get the diff. Read full files when the diff alone isn't enough context.
+Write your review in three sections. For every finding: file:line reference, what's wrong, concrete fix, confidence [0-100].
+
+---
+
+### Code Quality Review
+
+Direct, practical, no-nonsense. If code is fine, say it. If something needs work, show the fix.
+
+Review for:
+1. **Unnecessary complexity** - Code that could be simpler. Contrived abstractions.
+2. **Performance** - Multiple iterations when one would do, missing optimization, N+1 queries.
+3. **Naming & consistency** - Mixed conventions, unclear names.
+4. **Dead code** - Remove it. Don't comment it out.
 5. **Error handling** - Are errors caught and handled appropriately?
-6. **Testing** - Are changes tested? Are tests meaningful?
+6. **Testing** - Are changes tested? Do tests cover the changed path, not just happy paths?
+7. **Simpler alternatives** - Show the cleaner way when one exists.
 
-For each finding, provide:
-- File:line reference
-- What the issue is
-- Suggested fix (with code block)
+---
 
-Be direct. If code is fine, say so.
-```
+### Systems Review (Gilfoyle)
 
-### Agent 2: Systems Reviewer
+You are Gilfoyle — sharp, direct, occasionally withering. You don't pad feedback.
+If code is good, a curt acknowledgment. If it's bad, you say exactly why with the fix.
 
-@gilfoyle.md
+Review for:
+1. **Blast radius** - Shared state, critical paths, hot code paths. Is risk proportional to test coverage?
+2. **Failure modes** - What happens when this throws? Partial-success scenarios? Missing cleanup?
+3. **Abstraction theater** - Wrappers that add nothing, interfaces with one implementation.
+4. **Data flow integrity** - Inputs validated at boundaries? Race conditions? Ordering assumptions?
+5. **Implicit coupling** - Hidden dependencies on execution order, env vars, config, sibling behavior.
+6. **Rollback safety** - Can this be reverted cleanly? Migrations or state mutations that make rollback dangerous?
+7. **Consistency across boundaries** - Fixed here but not the three other places with the same pattern?
 
-## Collecting Results
+End with a verdict: **SHIP IT**, **FIX THEN SHIP**, or **NOPE**.
 
-After both agents complete, present a unified review:
+---
+
+### Repo Practices
+
+If the scouts found repo-specific guidance (CLAUDE.md, AGENTS.md, .claude/rules/), check compliance.
+If no repo guidance exists, skip this section entirely.
+
+Check for:
+1. Violations of documented conventions
+2. Patterns that conflict with repo standards
+3. Missing verification steps the repo expects (lint, types, tests)
+
+---
+
+## Output Format
+
+For each finding in every section: file:line, what's wrong, code fix, confidence [0-100].
 
 ```markdown
-## Code Review Summary
+### Code Quality — N finding(s)
+- [90] `src/foo.py:42` — This could be simpler. ```suggestion ...```
 
-### Code Quality
-[Agent 1 findings]
+### Systems Review (Gilfoyle) — N finding(s)
+- [85] `src/bar.py:10` — No error handling. Silent failure incoming.
 
-### Systems Review
-[Agent 2 findings]
+### Repo Practices — N finding(s)
+- [95] `src/baz.py:3` — Violates documented convention X.
 
-### Overall Assessment
-- **Blocking issues:** <count>
-- **Warnings:** <count>
-- **Notes:** <count>
-- **Verdict:** <APPROVE / REQUEST CHANGES / NEEDS DISCUSSION>
+**Verdict: FIX THEN SHIP**
+Two real issues. Fix them and ship.
 ```
+
+If the code is fine, say "SHIP IT" and move on. Don't manufacture drama for working code.
+````
+
+---
+
+## Phase 3: Confidence Filter (Haiku, parallel)
+
+For each finding from Phase 2, spawn a **parallel Haiku agent** to independently verify it.
+
+```
+You are a code review quality filter. Score this finding for confidence.
+
+## Finding
+<finding_text>
+
+## Diff Context
+<relevant_diff_section>
+
+## Repo Rules
+<relevant_guidance_files>
+
+## Scoring Rubric
+- 0: False positive. Pre-existing issue. Doesn't hold up.
+- 25: Might be real. Stylistic, not in repo guidance.
+- 50: Real but nitpicky. Not important for this PR.
+- 75: Verified real. Will be hit in practice. Important.
+- 100: Definitely real. Blocking.
+
+## Drop to 0 if ANY apply:
+- Pre-existing issue not introduced by this PR
+- Linter/CI would catch it
+- Intentional change related to the PR's purpose
+- Lines the author didn't modify
+- General nit not required by repo guidance
+- Silenced by lint-ignore comment
+
+Return ONLY: { "score": <number>, "reason": "<1 sentence>" }
+```
+Use `model: "haiku"`.
+
+**Filter**: Drop everything below **75**.
+
+---
+
+## Final Output
+
+Present surviving findings grouped by section, preserving each reviewer's voice:
+
+```markdown
+## Code Review
+
+### Code Quality — N finding(s)
+[filtered findings]
+
+### Systems Review (Gilfoyle) — N finding(s)
+[filtered findings + verdict]
+
+### Repo Practices — N finding(s)
+[filtered findings, or omitted if no repo guidance]
+
+### Evidence Missing
+- [what the PR does not prove and why that matters]
+
+### What Looks Good
+- [brief positive notes]
+
+## Overall
+- Risk: low | medium | high
+- Recommendation: SHIP IT | FIX THEN SHIP | NOPE
+```
+
+If all findings were filtered out, verdict is SHIP IT.
+
+## Execution Summary
+
+1. Get the diff
+2. **Phase 1**: Spawn Repo Context + History scouts (2 Haiku, parallel)
+3. Collect scout results
+4. **Phase 2**: Spawn the reviewer (1 Sonnet, gets scout context, can dispatch investigator on-demand)
+5. Collect findings
+6. **Phase 3**: Spawn N scoring agents (Haiku, parallel, one per finding)
+7. Filter to 75+ confidence
+8. Present final review with "Evidence Missing" and "What Looks Good" sections
 
 ## Rules
 
-- **Both agents get the full diff** and access to read the codebase.
-- **No duplicates.** If both agents flag the same issue, deduplicate in the summary.
-- **Actionable.** Every finding must have a concrete suggestion.
+- **Repo guidance wins.** If CLAUDE.md or AGENTS.md exist, they override generic advice.
+- **No duplicates.** Deduplicate across sections.
+- **Actionable.** Every finding must have a concrete suggestion with file:line.
+- **Evidence Missing matters.** Call out what the PR doesn't prove (rollback, monitoring, test coverage) — don't silently assume it's fine.
+- **State scope.** If you reviewed only staged changes or a subset, say so clearly.

--- a/ai/skills/rreview/gilfoyle.md
+++ b/ai/skills/rreview/gilfoyle.md
@@ -1,38 +1,46 @@
 # Gilfoyle - Systems Reviewer Prompt
 
-You are a systems-minded code reviewer. You focus on risks that surface-level review misses.
+You are Gilfoyle — somewhere between Linus Torvalds and Bertram Gilfoyle. Sharp, direct, occasionally withering. You don't pad feedback. If code is good, a curt acknowledgment. If it's bad, you say exactly why with the fix.
 
 ## Review Criteria
 
 ### Blast Radius
-- What breaks if this change is wrong?
+- What breaks if this change is wrong? Is risk proportional to test coverage?
 - How many callers / consumers are affected?
 - Is the failure contained or does it cascade?
 
 ### Failure Modes
 - What happens when the new code throws?
-- Are there unhandled edge cases in error paths?
-- Is there a partial-success scenario that leaves bad state?
+- Partial-success scenarios that leave bad state?
+- Missing cleanup in finally blocks for clients, connections, locks, files?
 
 ### Abstraction Theater
-- Does a new abstraction earn its keep, or does it just move complexity?
-- Is indirection hiding logic that callers need to understand?
+- Wrappers that add nothing, interfaces with one implementation.
+- A type + context + hook for a single boolean = failure.
 - Would inlining be clearer?
 
 ### Data Flow Integrity
 - Are inputs validated at the boundary?
-- Can data arrive in an unexpected shape downstream?
-- Are there race conditions or ordering assumptions?
+- Race conditions or ordering assumptions?
+- Derived values stored as state instead of computed?
 
 ### Implicit Coupling
-- Does this change assume something about another system's behavior?
-- Are there hidden dependencies on execution order, env vars, or config?
+- Hidden dependencies on execution order, env vars, config, sibling behavior?
 - Would a change in a sibling module silently break this?
 
 ### Rollback Safety
 - Can this be reverted cleanly?
-- Are there migrations, schema changes, or state mutations that make rollback dangerous?
+- Migrations, schema changes, or state mutations that make rollback dangerous?
 - Is there a feature flag or gradual rollout path?
+
+### Consistency Across Boundaries
+- Fixed it here but not the three other places with the same pattern?
+- Half-fixes are tech debt with interest.
+
+### Test Theater
+- Tests that pass because they don't test the right thing.
+- Missing negative cases. Snapshots on things that change every sprint.
+- Tests that assert a 200 or a count but not the changed contract.
 
 ## Output
 
@@ -40,6 +48,6 @@ For each finding, provide:
 - Severity: CRITICAL / WARNING / NOTE
 - File:line reference
 - Category from the list above
-- Description and recommendation
+- Description and concrete fix
 
-End with a summary: findings by severity, overall risk, and whether safe to merge.
+End with a verdict: **SHIP IT**, **FIX THEN SHIP**, or **NOPE**. Be honest. If it's fine, say "ship it" and move on.

--- a/ai/skills/rreview/gilfoyle.md
+++ b/ai/skills/rreview/gilfoyle.md
@@ -1,0 +1,45 @@
+# Gilfoyle - Systems Reviewer Prompt
+
+You are a systems-minded code reviewer. You focus on risks that surface-level review misses.
+
+## Review Criteria
+
+### Blast Radius
+- What breaks if this change is wrong?
+- How many callers / consumers are affected?
+- Is the failure contained or does it cascade?
+
+### Failure Modes
+- What happens when the new code throws?
+- Are there unhandled edge cases in error paths?
+- Is there a partial-success scenario that leaves bad state?
+
+### Abstraction Theater
+- Does a new abstraction earn its keep, or does it just move complexity?
+- Is indirection hiding logic that callers need to understand?
+- Would inlining be clearer?
+
+### Data Flow Integrity
+- Are inputs validated at the boundary?
+- Can data arrive in an unexpected shape downstream?
+- Are there race conditions or ordering assumptions?
+
+### Implicit Coupling
+- Does this change assume something about another system's behavior?
+- Are there hidden dependencies on execution order, env vars, or config?
+- Would a change in a sibling module silently break this?
+
+### Rollback Safety
+- Can this be reverted cleanly?
+- Are there migrations, schema changes, or state mutations that make rollback dangerous?
+- Is there a feature flag or gradual rollout path?
+
+## Output
+
+For each finding, provide:
+- Severity: CRITICAL / WARNING / NOTE
+- File:line reference
+- Category from the list above
+- Description and recommendation
+
+End with a summary: findings by severity, overall risk, and whether safe to merge.

--- a/ai/skills/simplify/SKILL.md
+++ b/ai/skills/simplify/SKILL.md
@@ -1,0 +1,86 @@
+---
+name: simplify
+description: Review changed code for unnecessary complexity and simplify with approval
+---
+
+# Simplify - Code Simplifier
+
+Review recently modified files for unnecessary complexity. Language-agnostic best practices applied with surgical precision.
+
+## Triggers
+
+- `/simplify` - Review recently changed files
+- `/simplify <file-path>` - Review a specific file
+
+## Getting the Targets
+
+1. If a file path is provided, use that file
+2. Otherwise, find recently modified files: `git diff --name-only HEAD~1` or `git diff --name-only` for uncommitted changes
+3. Read each target file in full
+
+## Simplification Checklist
+
+Look for these patterns and fix them:
+
+### Flatten Nesting
+- Early returns instead of nested if/else
+- Guard clauses at the top of functions
+- Reduce indentation depth
+
+### Prefer Standard Library
+- Replace hand-rolled utilities with stdlib equivalents
+- Use built-in data structures over custom ones
+- Leverage language-native patterns
+
+### Remove Dead Code
+- Unused imports, variables, functions
+- Commented-out code blocks
+- Unreachable branches
+
+### Simplify Conditionals
+- Collapse redundant boolean expressions
+- Replace complex ternaries with if/else or early returns
+- Use truthiness checks where appropriate
+
+### Reduce Abstraction
+- Inline single-use helper functions
+- Remove wrapper functions that add no value
+- Flatten unnecessary class hierarchies
+
+### Tighten Scope
+- Move declarations closer to usage
+- Reduce variable lifetime
+- Extract only when it improves readability
+
+## Process
+
+1. Read the target files
+2. Identify simplification opportunities
+3. Present each finding with before/after code blocks:
+
+```
+### Finding: <description>
+**File:** path/to/file.ts:42
+
+**Before:**
+\`\`\`
+<original code>
+\`\`\`
+
+**After:**
+\`\`\`
+<simplified code>
+\`\`\`
+
+**Why:** <brief explanation>
+```
+
+4. Ask for approval before applying any changes
+5. Only apply approved changes
+
+## Rules
+
+- **Never change behavior.** Simplification must be semantically equivalent.
+- **Show before applying.** Always present changes before making them.
+- **One concern per finding.** Keep findings atomic and reviewable.
+- **Skip if clean.** If the code is already simple, say so and move on.

--- a/ai/skills/spec-check/SKILL.md
+++ b/ai/skills/spec-check/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: spec-check
+description: Validate implementation against a provided spec and output a compliance matrix
+---
+
+# Spec Check - Spec Guardian
+
+Validate that an implementation matches a provided specification. Outputs a compliance matrix with evidence.
+
+## Triggers
+
+- `/spec-check <spec-path>` - Validate current branch against a spec file
+- `/spec-check <spec-path> <PR-number>` - Validate a PR against a spec
+
+## Process
+
+### 1. Load the Spec
+
+Read the spec file provided. Extract each discrete requirement. A requirement is any statement that describes expected behavior, constraints, or outputs.
+
+Number each requirement sequentially (R1, R2, R3...).
+
+### 2. Load the Implementation
+
+- If PR number provided: get changed files via `gh pr diff <number> --name-only`, then read each file
+- If on a branch: get changed files via `git diff origin/master..HEAD --name-only`, then read each file
+- Also read any files referenced by the changes (imports, configs)
+
+### 3. Check Each Requirement
+
+For every requirement, determine:
+
+| Status | Meaning |
+|--------|---------|
+| **PASS** | Requirement is fully implemented with evidence |
+| **FAIL** | Requirement is not implemented or implemented incorrectly |
+| **PARTIAL** | Requirement is partially implemented — some aspects missing |
+| **MISSING** | No evidence of implementation found anywhere |
+
+### 4. Gather Evidence
+
+For each requirement, find the specific file:line that implements it (or should implement it).
+
+## Output Format
+
+```markdown
+## Spec Compliance Report
+
+**Spec:** <spec filename>
+**Implementation:** <branch name or PR number>
+**Date:** <current date>
+
+### Compliance Matrix
+
+| Req | Description | Status | Evidence | Notes |
+|-----|-------------|--------|----------|-------|
+| R1 | <requirement text> | PASS | `src/auth.ts:42` | Implements JWT validation as specified |
+| R2 | <requirement text> | FAIL | `src/api.ts:15` | Returns 200 instead of 201 on create |
+| R3 | <requirement text> | PARTIAL | `src/db.ts:88` | Migration exists but missing rollback |
+| R4 | <requirement text> | MISSING | - | No implementation found |
+
+### Summary
+- **Total:** <N> requirements
+- **PASS:** <n> | **FAIL:** <n> | **PARTIAL:** <n> | **MISSING:** <n>
+- **Compliance:** <percentage>%
+
+### Blocking Issues
+<List any FAIL or MISSING items that must be resolved>
+
+### Recommendations
+<Suggestions for resolving PARTIAL and FAIL items>
+```
+
+## Rules
+
+- **Literal matching.** Check what the spec says, not what you think it should say.
+- **Evidence required.** Every PASS needs a file:line reference.
+- **No assumptions.** If you can't find evidence, it's MISSING.
+- **Read-only.** This skill only reports — it never modifies files.

--- a/ai/templates/agents-reviews.md
+++ b/ai/templates/agents-reviews.md
@@ -1,0 +1,83 @@
+---
+description: Copy to repo root as AGENTS.reviews.md — review standards for local skills and CI reviewers
+---
+
+# Review Standards
+
+Use this file for PR review agents. It provides shared standards so local skills and CI reviewers apply the same guidance.
+
+If this file and `AGENTS.md` conflict, `AGENTS.md` wins.
+
+## Review Contract
+
+- Be direct.
+- If code is fine, say so plainly.
+- If something needs work, call it out with a concrete suggestion.
+- Reference specific `file:line` locations.
+- Bias toward correctness, safety, and maintainability over style.
+- Skip style nits the linter already handles.
+- If rollout order, rollback steps, observability, or test coverage are not proven by the PR, call that out under **Evidence Missing** instead of assuming it is fine.
+- Review the supplied PR scope as the source of truth. Do not invent a broader scope.
+
+## Review Lanes
+
+### 1. Code Quality
+
+Look for:
+
+1. **Unnecessary complexity** — code that can be deleted or simplified.
+2. **Wrong abstraction level** — logic living in the wrong layer.
+3. **Performance issues** — N+1s, repeated work, import-time side effects, needless loops.
+4. **Existing helpers** — reuse existing patterns before inventing more code.
+5. **Test gaps** — exact changed path, especially negative and boundary cases.
+6. **Behavior mismatch** — names, logs, and messages that don't match what the code does.
+
+### 2. Systems & Reliability
+
+Look for:
+
+1. **Blast radius** — shared components, critical paths, hot code paths, auth paths.
+2. **Failure modes** — timeouts, retries, partial failure, missing cleanup.
+3. **Abstraction theater** — wrappers that add nothing, interfaces with one implementation.
+4. **Data flow integrity** — inputs validated at boundaries, race conditions, ordering assumptions.
+5. **Rollback safety** — migrations, state mutations, schema changes that make rollback dangerous.
+6. **Observability** — no clear signal that a risky change is failing beyond manual log-diving.
+
+### 3. Security
+
+Look for:
+
+1. **Auth and permissions** — accidental access expansion, missing deny paths.
+2. **Secret leakage** — logs, responses, fixtures, query params, raw error bodies.
+3. **Input validation** — injection, XSS, command injection at system boundaries.
+4. **Audit trails** — risky actions should be observable and traceable.
+
+### 4. Repo Practices
+
+Check compliance with documented conventions in CLAUDE.md, AGENTS.md, .claude/rules/.
+If no conventions are documented, skip this lane.
+
+## Output Format
+
+```markdown
+## PR Review Summary
+
+### Blocking
+- [finding with `path:line` and reason]
+
+### Major
+- [finding with `path:line` and reason]
+
+### Minor
+- [finding with `path:line` and reason]
+
+### Evidence Missing
+- [what the PR does not prove and why that matters]
+
+### What Looks Good
+- [brief positive notes]
+
+## Overall Verdict
+- Risk: low | medium | high
+- Recommendation: SHIP IT | FIX THEN SHIP | NOPE
+```

--- a/ai/templates/rules/python-patterns.md
+++ b/ai/templates/rules/python-patterns.md
@@ -1,0 +1,38 @@
+---
+description: Copy to .claude/rules/ — Python patterns and Django conventions
+paths:
+  - "**/*.py"
+---
+
+# Python Patterns
+
+## Type Hints
+
+- Use primitive types: `list`, `dict`, `set`, `tuple`
+- Use `Optional[T]` over `T | None`
+- Only import from `typing` when no primitive alternative exists
+- All functions must have fully typed arguments and return types
+- Never use `Any` except for complex nested dictionary responses
+
+## Function Design
+
+- Function names should clearly convey responsibility
+- Single responsibility: one function, one job
+- Public functions get full docstrings (Args, Returns, Raises)
+- Private helpers may omit docstrings if the name is self-explanatory
+
+## Django Conventions
+
+- Keep views thin — business logic in use cases or services
+- Prefer declarative serializers, filters, and pagination over custom methods
+- Use `transaction.atomic()` for multi-write mutations
+- Use `transaction.on_commit()` for side effects that depend on committed rows
+- Watch for N+1 queries — use `select_related` and `prefetch_related`
+
+## Testing
+
+- Tests named `test_<function_name>_<suffix>`
+- First test has no suffix (base case), subsequent tests describe the specific case
+- Use `assert` for value comparisons, assertion methods only for mock calls
+- Parametrize similar test cases with `@pytest.mark.parametrize`
+- Test the changed path specifically, not just nearby happy paths

--- a/ai/templates/rules/react-patterns.md
+++ b/ai/templates/rules/react-patterns.md
@@ -1,0 +1,61 @@
+---
+description: Copy to .claude/rules/ — React patterns and useEffect anti-patterns
+paths:
+  - "**/*.{ts,tsx,jsx}"
+---
+
+# React Patterns
+
+Before writing or preserving any `useEffect`, ask: "Is this synchronizing with an external system?" If not, remove it.
+
+## Derived State — Just Calculate It
+
+If a value can be computed from props or state, it's not state.
+
+```typescript
+// BAD: effect syncing derived state
+const [fullName, setFullName] = useState('');
+useEffect(() => { setFullName(firstName + ' ' + lastName); }, [firstName, lastName]);
+
+// GOOD: derive during render
+const fullName = firstName + ' ' + lastName;
+
+// GOOD: expensive? useMemo, not useEffect
+const filtered = useMemo(() => expensiveFilter(items, query), [items, query]);
+```
+
+## Reset State — Use `key`, Not Effects
+
+```typescript
+// BAD: effect clears state on prop change
+useEffect(() => { setComment(''); }, [userId]);
+
+// GOOD: key forces remount
+<Profile userId={userId} key={userId} />
+```
+
+## Event Logic — Keep It in Handlers
+
+```typescript
+// BAD: effect watches state set by handler
+useEffect(() => { if (data) post('/api', data); }, [data]);
+function handleSubmit() { setData({ name }); }
+
+// GOOD: just do it in the handler
+function handleSubmit() { post('/api', { name }); }
+```
+
+## When Effects ARE Correct
+
+- Data fetching (prefer React Query / SWR)
+- Subscriptions to external systems (prefer `useSyncExternalStore`)
+- Analytics on mount
+- Direct DOM manipulation (focus, scroll, measure)
+
+## Simplification Defaults
+
+- Clarity over cleverness — three explicit lines beat one dense expression
+- No nested ternaries — use if/else, switch, or lookup objects
+- No redundant abstractions — if a wrapper adds nothing, don't create it
+- Remove dead code — don't comment it out
+- Use existing libraries before hand-rolling

--- a/ai/templates/rules/typescript-patterns.md
+++ b/ai/templates/rules/typescript-patterns.md
@@ -1,0 +1,72 @@
+---
+description: Copy to .claude/rules/ — TypeScript patterns and type safety
+paths:
+  - "**/*.{ts,tsx}"
+---
+
+# TypeScript Patterns
+
+Make illegal states unrepresentable. Let the compiler do the work.
+
+## Derive, Don't Duplicate
+
+If a type can be derived from a source of truth, it must be.
+
+```typescript
+// BAD: manual duplication — these will drift
+type Status = 'active' | 'inactive' | 'pending';
+const STATUS_OPTIONS = ['active', 'inactive', 'pending'];
+
+// GOOD: single source of truth
+const STATUS = { ACTIVE: 'active', INACTIVE: 'inactive', PENDING: 'pending' } as const;
+type Status = (typeof STATUS)[keyof typeof STATUS];
+
+// GOOD: derive from arrays
+const ROLES = ['admin', 'editor', 'viewer'] as const;
+type Role = (typeof ROLES)[number];
+
+// GOOD: derive from functions
+type UserData = Awaited<ReturnType<typeof fetchUser>>;
+```
+
+## `satisfies` Over Type Annotations
+
+Annotations widen. `satisfies` validates the shape while preserving literal types.
+
+```typescript
+// BAD: annotation widens — loses literal types
+const routes: Record<string, { path: string }> = { home: { path: '/' } };
+
+// GOOD: satisfies validates but preserves literals
+const routes = { home: { path: '/' } } as const satisfies Record<string, { path: string }>;
+```
+
+## Discriminated Unions Over Bags of Optionals
+
+```typescript
+// BAD: nothing stops error + data coexisting
+type State = { status: string; data?: User[]; error?: string };
+
+// GOOD: illegal states unrepresentable
+type State =
+  | { status: 'idle' }
+  | { status: 'loading' }
+  | { status: 'success'; data: User[] }
+  | { status: 'error'; error: string };
+```
+
+## Narrowing — Use What TypeScript Gives You
+
+- **`in` operator** for object shape discrimination
+- **Type predicates** (`value is T`) for reusable narrowing
+- **Throw to narrow** — `if (!el) throw new Error('missing')` narrows from here on
+- **Never use `as` when you can narrow** — assertions lie, narrowing proves
+
+## Cardinal Rules
+
+1. **Never `any`** — use `unknown` and narrow
+2. **Never enums** — use `as const` objects with derived unions
+3. **Never duplicate what you can derive** — `keyof typeof`, `ReturnType`, `Parameters`
+4. **Never widen when you can `satisfies`** — validate without losing literals
+5. **Never bag-of-optionals when you can discriminate** — model states explicitly
+6. **Never `as` when you can narrow** — assertions lie, narrowing proves

--- a/ai/tools.json
+++ b/ai/tools.json
@@ -31,7 +31,9 @@
         {"source": "AGENTS.md", "target": "AGENTS.md"},
         {"source": "opencode.json", "target": "opencode.json"}
       ],
-      "skills_symlink": {"source": "skills", "target": "command"}
+      "skills_symlink": {"source": "skills", "target": "command"},
+      "agents_symlink": {"source": "modules/opencode/agents", "target": "agents"},
+      "extra_skills_dirs": ["work/skills"]
     },
     "cursor": {
       "name": "Cursor",

--- a/ai/tools.json
+++ b/ai/tools.json
@@ -55,6 +55,15 @@
       "config_dir": "~/Library/Application Support/Code/User",
       "tool_dir": "modules/vscode",
       "symlinks": []
+    },
+    "codex": {
+      "name": "Codex CLI",
+      "config_dir": "~/.codex",
+      "tool_dir": "modules/codex",
+      "symlinks": [
+        {"source": "AGENTS.md", "target": "AGENTS.md"}
+      ],
+      "bootstrap": "bootstrap.sh"
     }
   }
 }

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -146,6 +146,10 @@ installs happen — for example, `modules/codex/bootstrap.sh` runs
 `npm install -g @openai/codex oh-my-codex` and `omx setup`. Bootstrap
 scripts must be idempotent.
 
+Bootstrap requires a TTY on first run — `omx setup` may prompt
+interactively. `inv setup` already uses `pty=True`, so this is only
+relevant if someone calls `scripts/setup.py` directly in CI.
+
 ## Setup Flow
 
 ```bash

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -124,13 +124,19 @@ For each tool, after the public module is deployed, `setup.py` checks for
 
 | Overlay file | Action |
 |---|---|
-| `*.json` | Deep-merged into the deployed config of the same name (overlay wins). If the deployed path is a symlink to the public module, it is broken first so the merge does not pollute the source. |
 | `*.sh` | Made executable and run. Intended for idempotent setup scripts (e.g., generating provider URLs from env/email). |
-| any other file | Symlinked into the config directory with the same name. |
+| any other file | Symlinked into the config directory with the same name, fully replacing any public file of that name. |
 
 The overlay phase is opt-in by presence: no flags, no profile system. If
 `ai/work/modules/<tool_id>/` is absent or empty, the public module ships
 untouched. To reset cleanly after changing overlays, run `inv reset && inv setup`.
+
+### Backporting settings changes
+
+When you edit a file in `ai/modules/<tool>/` that also has a work overlay
+counterpart in `ai/work/modules/<tool>/`, the overlay copy must be
+hand-updated. Overlays fully replace the public file — they do not
+merge. Nothing detects drift automatically.
 
 ### Bootstrap
 

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -9,6 +9,7 @@ ai/
 ├── memory/             Shared memory files (@-imported by tool-specific CLAUDE.md)
 ├── modules/            Per-tool configs deployed via symlink
 │   ├── claude/         Claude Code: CLAUDE.md, hooks/, settings.json, statusline.sh
+│   ├── codex/          Codex CLI + oh-my-codex: AGENTS.md, bootstrap.sh
 │   ├── gemini/         Gemini CLI: GEMINI.md
 │   ├── opencode/       OpenCode: AGENTS.md, opencode.json, agents/
 │   ├── cursor/         Cursor
@@ -17,7 +18,9 @@ ai/
 ├── skills/             Shared skill definitions (consumed by all supporting tools)
 ├── templates/          Reusable templates for repo-level files
 ├── tools.json          Tool registry — schema below
-└── work/               Work-specific configs (gitignored, not committed)
+└── work/               Work-specific overrides (gitignored, not committed)
+    ├── modules/        Per-tool overlays, mirrors modules/ layout
+    └── skills/         Work-specific skills (picked up via extra_skills_dirs)
 ```
 
 ## tools.json Schema
@@ -49,6 +52,7 @@ Each tool entry in `tools.json` defines how `scripts/setup.py` deploys it:
     "target": "commands",
     "format": "toml"
   },
+  "bootstrap": "bootstrap.sh",    // Script run from tool_dir before symlinks (e.g., npm install)
   "extra_skills_dirs": ["work/skills"]  // Additional skills dirs (e.g., gitignored work skills)
 }
 ```
@@ -81,9 +85,9 @@ OpenCode agents live in `ai/modules/opencode/agents/*.md` with frontmatter:
 description: Read-only codebase cartographer
 color: "#4169E1"
 tools:
-  - read
-  - glob
-  - grep
+  read: true
+  glob: true
+  grep: true
 ---
 ```
 
@@ -102,12 +106,39 @@ Templates have a `description` in frontmatter explaining their purpose and where
 
 ## Work Directory
 
-`ai/work/` is gitignored. Use it for:
-- Work-specific skills (`ai/work/skills/`)
-- Provider setup scripts
-- Anything that shouldn't be committed to a public repo
+`ai/work/` is gitignored. Its layout mirrors `ai/modules/` so work-specific
+overrides are per-tool:
 
-Tools with `extra_skills_dirs: ["work/skills"]` will pick up skills from here during setup.
+```
+ai/work/
+├── modules/
+│   ├── codex/          # e.g., config.toml with IC AI Gateway provider
+│   └── opencode/       # e.g., setup-providers.sh, overlay JSON
+└── skills/             # work-specific skills (symlinked via extra_skills_dirs)
+```
+
+### How overlays are applied
+
+For each tool, after the public module is deployed, `setup.py` checks for
+`ai/work/modules/<tool_id>/`. If present, each file is handled by extension:
+
+| Overlay file | Action |
+|---|---|
+| `*.json` | Deep-merged into the deployed config of the same name (overlay wins). If the deployed path is a symlink to the public module, it is broken first so the merge does not pollute the source. |
+| `*.sh` | Made executable and run. Intended for idempotent setup scripts (e.g., generating provider URLs from env/email). |
+| any other file | Symlinked into the config directory with the same name. |
+
+The overlay phase is opt-in by presence: no flags, no profile system. If
+`ai/work/modules/<tool_id>/` is absent or empty, the public module ships
+untouched. To reset cleanly after changing overlays, run `inv reset && inv setup`.
+
+### Bootstrap
+
+Tools with `"bootstrap": "<script>.sh"` run the named script from their
+`tool_dir` before any symlinks are laid down. This is where package
+installs happen — for example, `modules/codex/bootstrap.sh` runs
+`npm install -g @openai/codex oh-my-codex` and `omx setup`. Bootstrap
+scripts must be idempotent.
 
 ## Setup Flow
 

--- a/docs/ai-tools.md
+++ b/docs/ai-tools.md
@@ -1,0 +1,128 @@
+# AI Tools
+
+The `ai/` directory manages configurations for multiple AI CLI tools from a single source of truth.
+
+## Overview
+
+```
+ai/
+├── memory/             Shared memory files (@-imported by tool-specific CLAUDE.md)
+├── modules/            Per-tool configs deployed via symlink
+│   ├── claude/         Claude Code: CLAUDE.md, hooks/, settings.json, statusline.sh
+│   ├── gemini/         Gemini CLI: GEMINI.md
+│   ├── opencode/       OpenCode: AGENTS.md, opencode.json, agents/
+│   ├── cursor/         Cursor
+│   ├── antigravity/    Antigravity
+│   └── vscode/         VS Code
+├── skills/             Shared skill definitions (consumed by all supporting tools)
+├── templates/          Reusable templates for repo-level files
+├── tools.json          Tool registry — schema below
+└── work/               Work-specific configs (gitignored, not committed)
+```
+
+## tools.json Schema
+
+Each tool entry in `tools.json` defines how `scripts/setup.py` deploys it:
+
+```jsonc
+{
+  "name": "Claude Code",          // Display name
+  "config_dir": "~/.claude",      // Where configs are deployed
+  "tool_dir": "modules/claude",   // Source directory (relative to ai/)
+  "symlinks": [                   // Files/dirs symlinked into config_dir
+    {"source": "CLAUDE.md", "target": "CLAUDE.md"}
+  ],
+  "settings_template": {          // Copy template if target doesn't exist
+    "template": "settings.template.json",
+    "target": "settings.json"
+  },
+  "skills_symlink": {             // Symlink individual skills into config_dir/target/
+    "source": "skills",
+    "target": "skills"
+  },
+  "agents_symlink": {             // Symlink agent .md files (OpenCode)
+    "source": "modules/opencode/agents",
+    "target": "agents"
+  },
+  "skills_generate": {            // Generate skill files (Gemini TOML, Cursor MD)
+    "source": "skills",
+    "target": "commands",
+    "format": "toml"
+  },
+  "extra_skills_dirs": ["work/skills"]  // Additional skills dirs (e.g., gitignored work skills)
+}
+```
+
+## Skills
+
+Skills live in `ai/skills/<skill-name>/SKILL.md`. Each skill is a markdown file with YAML frontmatter:
+
+```yaml
+---
+name: rreview
+description: Code review orchestrator with scout, review, and confidence filter phases
+argument-hint: "[PR-number]"
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Bash, Agent, Task
+---
+```
+
+Skills are deployed differently per tool:
+- **Claude Code / OpenCode / Antigravity**: Symlinked as directories into the tool's skills folder
+- **Gemini CLI**: Converted to TOML format and written to `~/.gemini/commands/`
+- **Cursor**: Copied as markdown to `~/.cursor/commands/`
+
+## Agents (OpenCode)
+
+OpenCode agents live in `ai/modules/opencode/agents/*.md` with frontmatter:
+
+```yaml
+---
+description: Read-only codebase cartographer
+color: "#4169E1"
+tools:
+  - read
+  - glob
+  - grep
+---
+```
+
+These are symlinked individually into `~/.config/opencode/agents/`.
+
+## Templates
+
+`ai/templates/` contains reusable templates meant to be copied into repo roots:
+
+- `agents-reviews.md` — Review standards (copy as `AGENTS.reviews.md`)
+- `rules/python-patterns.md` — Python code patterns (copy to `.claude/rules/`)
+- `rules/react-patterns.md` — React patterns
+- `rules/typescript-patterns.md` — TypeScript patterns
+
+Templates have a `description` in frontmatter explaining their purpose and where to place them.
+
+## Work Directory
+
+`ai/work/` is gitignored. Use it for:
+- Work-specific skills (`ai/work/skills/`)
+- Provider setup scripts
+- Anything that shouldn't be committed to a public repo
+
+Tools with `extra_skills_dirs: ["work/skills"]` will pick up skills from here during setup.
+
+## Setup Flow
+
+```bash
+# Deploy all tools
+python scripts/setup.py
+
+# Deploy a specific tool
+python scripts/setup.py claude
+
+# List available tools
+python scripts/setup.py --list
+```
+
+The setup script:
+1. Reads `ai/tools.json`
+2. For each tool: creates config dir, symlinks files, generates skills, copies templates
+3. Handles backups of existing non-symlink configs

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,73 @@
+# Architecture
+
+## Component Layout
+
+Each top-level directory is a self-contained component with its own `setup` script:
+
+| Component | What it does |
+|-----------|-------------|
+| `shell/` | ZSH config: `.zshrc`, `.zprofile`, plugins, performance tracking |
+| `terminal/` | Ghostty terminal emulator config |
+| `git/` | Git global config, aliases, global gitignore |
+| `direnv/` | direnv shell hook and direnvrc |
+| `lazygit/` | Lazygit TUI config |
+| `rectangle/` | Rectangle window manager plist (macOS only) |
+
+### Component Setup Contract
+
+Every component has a `setup` script that:
+1. Receives `REPO_DIR` as an environment variable
+2. Sources `lib/platform.sh` for cross-platform helpers
+3. Creates symlinks from the repo into `$HOME` or `~/.config/`
+4. Is idempotent — safe to run repeatedly
+
+### Shared Library (`lib/platform.sh`)
+
+Provides:
+- `detect_os` — returns `macos` or `linux`
+- `ensure_symlink <source> <target> <label>` — creates a symlink with backup
+- `ensure_zsh` — installs zsh if missing (Linux)
+- `get_zsh_path` — finds the zsh binary
+
+## Setup Pipeline
+
+```
+scripts/bootstrap          Install uv + Python
+    ↓
+inv setup                  Entry point (tasks.py)
+    ↓
+_setup_platform()          Install Homebrew (macOS) or verify sudo (Linux)
+    ↓
+_run_component()           Run each component's setup script in order:
+    ├── terminal/setup         Ghostty config symlink
+    ├── direnv/setup           direnvrc symlink
+    ├── git/setup              Git config, aliases, global gitignore
+    ├── lazygit/setup          Lazygit config
+    ├── rectangle/setup        Rectangle plist import (macOS)
+    └── shell/setup            .zprofile symlink, .zshrc loader creation
+    ↓
+scripts/setup.py           AI tools setup (reads ai/tools.json)
+```
+
+## Shell Configuration
+
+The shell setup uses a **loader pattern** to avoid conflicts with tools that modify `~/.zshrc`:
+
+1. `shell/.zshrc.loader` is a template with `__REPO_DIR__` placeholder
+2. `shell/setup` renders it into `~/.zshrc`, replacing the placeholder
+3. The loader sources `shell/.zshrc` (the real config)
+4. Everything below the `# Tools install themselves below this line` marker is preserved across re-runs
+
+This means:
+- The repo owns everything above the marker (shell config)
+- Tools own everything below the marker (their auto-installed lines)
+- `inv reset --keep` preserves the tool section during a full reset
+
+## Reset and Teardown
+
+`inv reset` calls `_teardown()` which:
+1. Removes all config symlinks and files
+2. Backs up `~/.zshrc` with a timestamp
+3. Resets git global config (`core.excludesfile`, `include.path`)
+4. Removes AI tool symlinks/configs (driven by `ai/tools.json`)
+5. Re-runs the full setup pipeline

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -19,7 +19,6 @@ import shutil
 import stat
 import subprocess
 import sys
-from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import TypedDict
@@ -455,66 +454,6 @@ def ensure_settings_from_template(tool_dir: Path, template_cfg: SettingsTemplate
 WORK_OVERLAY_ROOT = "work/modules"
 
 
-def deep_merge(base: Mapping[str, object], overlay: Mapping[str, object]) -> dict[str, object]:
-    """Recursively merge overlay into base. Overlay values win on leaves.
-
-    Nested dicts are merged key-by-key. Any non-dict value in overlay
-    replaces the corresponding value in base entirely (lists are not
-    concatenated — replacement only).
-
-    Args:
-        base: The base dict (not mutated).
-        overlay: The overlay dict whose values take precedence.
-
-    Returns:
-        A new merged dict.
-    """
-    result = dict(base)
-    for key, overlay_value in overlay.items():
-        base_value = result.get(key)
-        if isinstance(base_value, dict) and isinstance(overlay_value, dict):
-            result[key] = deep_merge(base_value, overlay_value)
-        else:
-            result[key] = overlay_value
-    return result
-
-
-def _merge_json_overlay(overlay_file: Path, target_file: Path) -> None:
-    overlay_data = json.loads(overlay_file.read_text())
-    if not isinstance(overlay_data, dict):
-        print_colored(
-            f"  Warning: overlay {overlay_file} is not a JSON object, skipping",
-            Colors.RED,
-        )
-        return
-
-    base_data: dict[str, object] = {}
-    if target_file.exists():
-        existing_text = target_file.read_text().strip()
-        if existing_text:
-            try:
-                loaded = json.loads(existing_text)
-                if isinstance(loaded, dict):
-                    base_data = loaded
-                else:
-                    print_colored(
-                        f"  Warning: {target_file} is not a JSON object; overwriting",
-                        Colors.YELLOW,
-                    )
-            except json.JSONDecodeError:
-                print_colored(
-                    f"  Warning: {target_file} is not valid JSON; overwriting",
-                    Colors.YELLOW,
-                )
-
-    merged = deep_merge(base_data, overlay_data)
-    target_file.parent.mkdir(parents=True, exist_ok=True)
-    if target_file.is_symlink():
-        target_file.unlink()
-    target_file.write_text(json.dumps(merged, indent=2) + "\n")
-    print_colored(f"  Merged overlay {overlay_file.name} into {target_file}", Colors.GREEN)
-
-
 def _run_overlay_script(script: Path) -> None:
     mode = script.stat().st_mode
     script.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
@@ -533,9 +472,9 @@ def apply_work_overlay(tool_id: str, config_dir: Path, ai_root: Path) -> bool:
     """Apply work-profile overlay for a tool, if present.
 
     Looks for ai/work/modules/<tool_id>/. If found:
-      - *.json: deep-merged into config_dir/<same-name>
       - *.sh: executed (user-managed, often idempotent provider setup)
-      - any other file: symlinked into config_dir/<same-name>
+      - any other file: symlinked into config_dir/<same-name>, fully
+        replacing the public file of the same name
 
     Args:
         tool_id: The tool identifier (e.g., "opencode", "codex").
@@ -556,9 +495,7 @@ def apply_work_overlay(tool_id: str, config_dir: Path, ai_root: Path) -> bool:
         if not entry.is_file():
             continue
 
-        if entry.suffix == ".json":
-            _merge_json_overlay(entry, config_dir / entry.name)
-        elif entry.suffix == ".sh":
+        if entry.suffix == ".sh":
             try:
                 _run_overlay_script(entry)
             except subprocess.CalledProcessError as exc:

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -32,6 +32,11 @@ class SkillsSymlink(TypedDict):
     target: str
 
 
+class AgentsSymlink(TypedDict):
+    source: str
+    target: str
+
+
 class SkillsGenerate(TypedDict):
     source: str
     target: str
@@ -56,6 +61,7 @@ class ToolConfig(TypedDict, total=False):
     symlinks: list[Symlink]
     settings_template: SettingsTemplate
     skills_symlink: SkillsSymlink
+    agents_symlink: AgentsSymlink
     skills_generate: SkillsGenerate
     memory_generate: MemoryGenerate
     extra_skills_dirs: list[str]
@@ -317,6 +323,42 @@ def symlink_skills_to_config(
     return success
 
 
+def symlink_agents_to_config(source_dir: Path, target_dir: Path) -> bool:
+    """Symlink individual agent .md files from source directory into the config agents directory.
+
+    Args:
+        source_dir: Directory containing agent .md files.
+        target_dir: The config agents directory (e.g., ~/.config/opencode/agents/).
+
+    Returns:
+        True if all symlinks were created successfully, False if any failed.
+    """
+    if not source_dir.exists():
+        print_colored(f"  Warning: Agents directory not found at {source_dir}", Colors.RED)
+        return False
+
+    backup_if_exists(target_dir)
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    md_files = list(source_dir.glob("*.md"))
+    if not md_files:
+        print_colored(f"  Warning: No agent files found in {source_dir}", Colors.YELLOW)
+        return False
+
+    print_colored(f"  Linking agents from {source_dir}", Colors.GREEN)
+
+    for md_file in md_files:
+        target_link = target_dir / md_file.name
+
+        if target_link.exists() or target_link.is_symlink():
+            target_link.unlink()
+
+        target_link.symlink_to(md_file)
+        print(f"    {md_file.name} -> {md_file}")
+
+    return True
+
+
 def generate_memory(source_dir: Path, config_dir: Path, target: str, mode: str) -> bool:
     """Concatenate or copy memory files for tools without @ import support.
 
@@ -454,6 +496,14 @@ def setup_tool(tool_id: str, tool_config: ToolConfig, ai_root: Path) -> bool:
                 skills_dirs.append(ai_root / extra_dir_str)
 
         if not symlink_skills_to_config(skills_dirs, target_dir, "skills"):
+            success = False
+
+    if "agents_symlink" in tool_config:
+        agents_cfg = tool_config["agents_symlink"]
+        source_dir = ai_root / agents_cfg["source"]
+        target_dir = config_dir / agents_cfg["target"]
+
+        if not symlink_agents_to_config(source_dir, target_dir):
             success = False
 
     if "skills_generate" in tool_config:

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -560,66 +560,71 @@ def setup_tool(tool_id: str, tool_config: ToolConfig, ai_root: Path) -> bool:
         config_dir.mkdir(parents=True)
 
     success = True
+    bootstrap_ok = True
 
     # Bootstrap runs first so the tool is installed before we deploy config.
     if "bootstrap" in tool_config and not run_bootstrap(tool_dir, tool_config["bootstrap"]):
+        bootstrap_ok = False
         success = False
 
-    # Handle settings template (must run before symlinks so the source file exists)
-    if "settings_template" in tool_config:
-        ensure_settings_from_template(tool_dir, tool_config["settings_template"])
+    if bootstrap_ok:
+        # Handle settings template (must run before symlinks so the source file exists)
+        if "settings_template" in tool_config:
+            ensure_settings_from_template(tool_dir, tool_config["settings_template"])
 
-    for symlink in tool_config.get("symlinks", []):
-        source = tool_dir / symlink["source"]
-        target = config_dir / symlink["target"]
+        for symlink in tool_config.get("symlinks", []):
+            source = tool_dir / symlink["source"]
+            target = config_dir / symlink["target"]
 
-        if not create_symlink(source, target, symlink["source"]):
+            if not create_symlink(source, target, symlink["source"]):
+                success = False
+
+        if "skills_symlink" in tool_config:
+            skills_cfg = tool_config["skills_symlink"]
+            source_dir = ai_root / skills_cfg["source"]
+            target_dir = config_dir / skills_cfg["target"]
+
+            backup_if_exists(target_dir)
+            target_dir.mkdir(parents=True, exist_ok=True)
+
+            skills_dirs = [source_dir]
+            for extra_dir_str in tool_config.get("extra_skills_dirs", []):
+                if extra_dir_str.startswith("~"):
+                    skills_dirs.append(Path(os.path.expanduser(extra_dir_str)))
+                else:
+                    skills_dirs.append(ai_root / extra_dir_str)
+
+            if not symlink_skills_to_config(skills_dirs, target_dir, "skills"):
+                success = False
+
+        if "agents_symlink" in tool_config:
+            agents_cfg = tool_config["agents_symlink"]
+            source_dir = ai_root / agents_cfg["source"]
+            target_dir = config_dir / agents_cfg["target"]
+
+            if not symlink_agents_to_config(source_dir, target_dir):
+                success = False
+
+        if "skills_generate" in tool_config:
+            skills_cfg = tool_config["skills_generate"]
+            source = ai_root / skills_cfg["source"]
+            target = config_dir / skills_cfg["target"]
+            fmt = skills_cfg.get("format", "md")
+            if not generate_skills(source, target, fmt):
+                success = False
+
+        if "memory_generate" in tool_config:
+            mem_cfg = tool_config["memory_generate"]
+            source = ai_root / mem_cfg["source"]
+            if not generate_memory(source, config_dir, mem_cfg["target"], mem_cfg["mode"]):
+                success = False
+
+        if not apply_work_overlay(tool_id, config_dir, ai_root):
             success = False
-
-    if "skills_symlink" in tool_config:
-        skills_cfg = tool_config["skills_symlink"]
-        source_dir = ai_root / skills_cfg["source"]
-        target_dir = config_dir / skills_cfg["target"]
-
-        backup_if_exists(target_dir)
-        target_dir.mkdir(parents=True, exist_ok=True)
-
-        skills_dirs = [source_dir]
-        for extra_dir_str in tool_config.get("extra_skills_dirs", []):
-            if extra_dir_str.startswith("~"):
-                skills_dirs.append(Path(os.path.expanduser(extra_dir_str)))
-            else:
-                skills_dirs.append(ai_root / extra_dir_str)
-
-        if not symlink_skills_to_config(skills_dirs, target_dir, "skills"):
-            success = False
-
-    if "agents_symlink" in tool_config:
-        agents_cfg = tool_config["agents_symlink"]
-        source_dir = ai_root / agents_cfg["source"]
-        target_dir = config_dir / agents_cfg["target"]
-
-        if not symlink_agents_to_config(source_dir, target_dir):
-            success = False
-
-    if "skills_generate" in tool_config:
-        skills_cfg = tool_config["skills_generate"]
-        source = ai_root / skills_cfg["source"]
-        target = config_dir / skills_cfg["target"]
-        fmt = skills_cfg.get("format", "md")
-        if not generate_skills(source, target, fmt):
-            success = False
-
-    if "memory_generate" in tool_config:
-        mem_cfg = tool_config["memory_generate"]
-        source = ai_root / mem_cfg["source"]
-        if not generate_memory(source, config_dir, mem_cfg["target"], mem_cfg["mode"]):
-            success = False
+    else:
+        print_colored(f"  Aborting {name} config deployment: bootstrap failed", Colors.RED)
 
     setup_shell_alias(tool_id)
-
-    if not apply_work_overlay(tool_id, config_dir, ai_root):
-        success = False
 
     return success
 

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -16,7 +16,10 @@ import argparse
 import json
 import os
 import shutil
+import stat
+import subprocess
 import sys
+from collections.abc import Mapping
 from datetime import datetime
 from pathlib import Path
 from typing import TypedDict
@@ -65,6 +68,7 @@ class ToolConfig(TypedDict, total=False):
     skills_generate: SkillsGenerate
     memory_generate: MemoryGenerate
     extra_skills_dirs: list[str]
+    bootstrap: str
 
 
 class ToolsConfig(TypedDict):
@@ -448,6 +452,157 @@ def ensure_settings_from_template(tool_dir: Path, template_cfg: SettingsTemplate
     return True
 
 
+WORK_OVERLAY_ROOT = "work/modules"
+
+
+def deep_merge(base: Mapping[str, object], overlay: Mapping[str, object]) -> dict[str, object]:
+    """Recursively merge overlay into base. Overlay values win on leaves.
+
+    Nested dicts are merged key-by-key. Any non-dict value in overlay
+    replaces the corresponding value in base entirely (lists are not
+    concatenated — replacement only).
+
+    Args:
+        base: The base dict (not mutated).
+        overlay: The overlay dict whose values take precedence.
+
+    Returns:
+        A new merged dict.
+    """
+    result = dict(base)
+    for key, overlay_value in overlay.items():
+        base_value = result.get(key)
+        if isinstance(base_value, dict) and isinstance(overlay_value, dict):
+            result[key] = deep_merge(base_value, overlay_value)
+        else:
+            result[key] = overlay_value
+    return result
+
+
+def _merge_json_overlay(overlay_file: Path, target_file: Path) -> None:
+    overlay_data = json.loads(overlay_file.read_text())
+    if not isinstance(overlay_data, dict):
+        print_colored(
+            f"  Warning: overlay {overlay_file} is not a JSON object, skipping",
+            Colors.RED,
+        )
+        return
+
+    base_data: dict[str, object] = {}
+    if target_file.exists():
+        existing_text = target_file.read_text().strip()
+        if existing_text:
+            try:
+                loaded = json.loads(existing_text)
+                if isinstance(loaded, dict):
+                    base_data = loaded
+                else:
+                    print_colored(
+                        f"  Warning: {target_file} is not a JSON object; overwriting",
+                        Colors.YELLOW,
+                    )
+            except json.JSONDecodeError:
+                print_colored(
+                    f"  Warning: {target_file} is not valid JSON; overwriting",
+                    Colors.YELLOW,
+                )
+
+    merged = deep_merge(base_data, overlay_data)
+    target_file.parent.mkdir(parents=True, exist_ok=True)
+    if target_file.is_symlink():
+        target_file.unlink()
+    target_file.write_text(json.dumps(merged, indent=2) + "\n")
+    print_colored(f"  Merged overlay {overlay_file.name} into {target_file}", Colors.GREEN)
+
+
+def _run_overlay_script(script: Path) -> None:
+    mode = script.stat().st_mode
+    script.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+    print_colored(f"  Running overlay script {script.name}", Colors.GREEN)
+    subprocess.run([str(script)], check=True)
+
+
+def _symlink_overlay_file(overlay_file: Path, target: Path) -> None:
+    backup_if_exists(target)
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.symlink_to(overlay_file)
+    print_colored(f"  Overlay symlink {overlay_file.name} -> {target}", Colors.GREEN)
+
+
+def apply_work_overlay(tool_id: str, config_dir: Path, ai_root: Path) -> bool:
+    """Apply work-profile overlay for a tool, if present.
+
+    Looks for ai/work/modules/<tool_id>/. If found:
+      - *.json: deep-merged into config_dir/<same-name>
+      - *.sh: executed (user-managed, often idempotent provider setup)
+      - any other file: symlinked into config_dir/<same-name>
+
+    Args:
+        tool_id: The tool identifier (e.g., "opencode", "codex").
+        config_dir: The tool's deployed config directory (e.g., ~/.codex).
+        ai_root: The ai/ directory root in the repo.
+
+    Returns:
+        True when overlay applied cleanly (or absent), False on script failure.
+    """
+    overlay_dir = ai_root / WORK_OVERLAY_ROOT / tool_id
+    if not overlay_dir.exists():
+        return True
+
+    print_colored(f"  Applying work overlay from {overlay_dir}", Colors.BLUE)
+    success = True
+
+    for entry in sorted(overlay_dir.iterdir()):
+        if not entry.is_file():
+            continue
+
+        if entry.suffix == ".json":
+            _merge_json_overlay(entry, config_dir / entry.name)
+        elif entry.suffix == ".sh":
+            try:
+                _run_overlay_script(entry)
+            except subprocess.CalledProcessError as exc:
+                print_colored(
+                    f"  Warning: overlay script {entry.name} exited {exc.returncode}",
+                    Colors.RED,
+                )
+                success = False
+        else:
+            _symlink_overlay_file(entry, config_dir / entry.name)
+
+    return success
+
+
+def run_bootstrap(tool_dir: Path, script_name: str) -> bool:
+    """Run a tool's bootstrap script from its module directory.
+
+    Args:
+        tool_dir: The tool's source directory (e.g. ai/modules/codex).
+        script_name: The bootstrap filename relative to tool_dir.
+
+    Returns:
+        True if the script exits zero or is absent; False if it fails.
+    """
+    script = tool_dir / script_name
+    if not script.exists():
+        print_colored(f"  Warning: bootstrap {script} not found, skipping", Colors.YELLOW)
+        return False
+
+    mode = script.stat().st_mode
+    script.chmod(mode | stat.S_IXUSR | stat.S_IXGRP | stat.S_IXOTH)
+
+    print_colored(f"  Running bootstrap {script_name}", Colors.GREEN)
+    try:
+        subprocess.run([str(script)], check=True)
+    except subprocess.CalledProcessError as exc:
+        print_colored(
+            f"  Warning: bootstrap exited {exc.returncode}",
+            Colors.RED,
+        )
+        return False
+    return True
+
+
 def setup_tool(tool_id: str, tool_config: ToolConfig, ai_root: Path) -> bool:
     name = tool_config["name"]
     config_dir = Path(os.path.expanduser(tool_config["config_dir"]))
@@ -468,6 +623,10 @@ def setup_tool(tool_id: str, tool_config: ToolConfig, ai_root: Path) -> bool:
         config_dir.mkdir(parents=True)
 
     success = True
+
+    # Bootstrap runs first so the tool is installed before we deploy config.
+    if "bootstrap" in tool_config and not run_bootstrap(tool_dir, tool_config["bootstrap"]):
+        success = False
 
     # Handle settings template (must run before symlinks so the source file exists)
     if "settings_template" in tool_config:
@@ -521,6 +680,9 @@ def setup_tool(tool_id: str, tool_config: ToolConfig, ai_root: Path) -> bool:
             success = False
 
     setup_shell_alias(tool_id)
+
+    if not apply_work_overlay(tool_id, config_dir, ai_root):
+        success = False
 
     return success
 

--- a/tasks.py
+++ b/tasks.py
@@ -54,6 +54,37 @@ def _load_ai_tool_paths() -> list[str]:
     return paths
 
 
+def _load_overlay_paths() -> list[str]:
+    """Derive overlay-deployed paths from ai/work/modules/<tool_id>/.
+
+    For each tool in tools.json, walk the matching overlay directory and
+    emit target paths for every file that setup.py would symlink. `.sh`
+    files are skipped: they execute arbitrary side effects whose outputs
+    aren't knowable from the filename alone, so teardown can't track them.
+
+    Returns:
+        List of paths relative to $HOME (e.g. ".codex/config.toml").
+    """
+    config_path = REPO_DIR / "ai" / "tools.json"
+    with open(config_path) as f:
+        config = json.load(f)
+
+    overlay_root = REPO_DIR / "ai" / "work" / "modules"
+    paths: list[str] = []
+    for tool_id, tool in config.get("tools", {}).items():
+        overlay_dir = overlay_root / tool_id
+        if not overlay_dir.exists():
+            continue
+
+        rel_dir = tool["config_dir"].removeprefix("~/")
+        for entry in sorted(overlay_dir.iterdir()):
+            if not entry.is_file() or entry.suffix == ".sh":
+                continue
+            paths.append(f"{rel_dir}/{entry.name}")
+
+    return paths
+
+
 def _extract_zshrc_tool_content() -> Optional[str]:
     """Extract tool-installed content from ~/.zshrc (everything from the marker onward).
 
@@ -196,7 +227,7 @@ def _teardown() -> None:
         print(f"  → Removing {starship}")
         starship.unlink()
 
-    for rel_path in _load_ai_tool_paths():
+    for rel_path in _load_ai_tool_paths() + _load_overlay_paths():
         path = home / rel_path
         if path.is_symlink():
             print(f"  → Removing AI symlink: {path}")

--- a/tasks.py
+++ b/tasks.py
@@ -42,6 +42,9 @@ def _load_ai_tool_paths() -> list[str]:
         if "skills_symlink" in tool:
             paths.append(f"{rel_dir}/{tool['skills_symlink']['target']}")
 
+        if "agents_symlink" in tool:
+            paths.append(f"{rel_dir}/{tool['agents_symlink']['target']}")
+
         if "skills_generate" in tool:
             paths.append(f"{rel_dir}/{tool['skills_generate']['target']}")
 

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,61 @@
+import re
+from pathlib import Path
+
+import pytest
+
+AGENTS_DIR = Path(__file__).resolve().parent.parent / "ai" / "modules" / "opencode" / "agents"
+
+
+def _get_agent_files() -> list[str]:
+    if not AGENTS_DIR.exists():
+        return []
+    return [f.stem for f in AGENTS_DIR.glob("*.md")]
+
+
+@pytest.mark.parametrize("agent_name", _get_agent_files())
+def test_agent_has_valid_frontmatter(agent_name: str) -> None:
+    agent_path = AGENTS_DIR / f"{agent_name}.md"
+    content = agent_path.read_text()
+
+    assert content.startswith("---"), f"{agent_path}: missing YAML frontmatter delimiter"
+
+    parts = content.split("---", 2)
+    assert len(parts) >= 3, f"{agent_path}: malformed frontmatter (missing closing ---)"
+
+    yaml_content = parts[1].strip()
+    frontmatter: dict[str, str] = {}
+    for line in yaml_content.split("\n"):
+        if ":" in line and not line.startswith(" "):
+            key, value = line.split(":", 1)
+            frontmatter[key.strip()] = value.strip()
+
+    assert "description" in frontmatter, f"{agent_path}: missing 'description' in frontmatter"
+    assert len(frontmatter["description"]) > 0, f"{agent_path}: empty description"
+
+
+@pytest.mark.parametrize("agent_name", _get_agent_files())
+def test_agent_has_body(agent_name: str) -> None:
+    agent_path = AGENTS_DIR / f"{agent_name}.md"
+    content = agent_path.read_text()
+
+    parts = content.split("---", 2)
+    body = parts[2].strip() if len(parts) >= 3 else ""
+    assert len(body) > 0, f"{agent_path}: empty body"
+
+
+@pytest.mark.parametrize("agent_name", _get_agent_files())
+def test_agent_color_is_valid_hex(agent_name: str) -> None:
+    agent_path = AGENTS_DIR / f"{agent_name}.md"
+    content = agent_path.read_text()
+
+    parts = content.split("---", 2)
+    yaml_content = parts[1] if len(parts) >= 3 else ""
+
+    color_match = re.search(r'^color:\s*["\']?(#[0-9A-Fa-f]+)["\']?', yaml_content, re.MULTILINE)
+    if color_match is None:
+        pytest.skip(f"Agent '{agent_name}' has no color field")
+
+    color = color_match.group(1)
+    assert re.fullmatch(r"#[0-9A-Fa-f]{6}", color), (
+        f"{agent_path}: invalid hex color '{color}' (expected #RRGGBB)"
+    )

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -59,3 +59,37 @@ def test_agent_color_is_valid_hex(agent_name: str) -> None:
     assert re.fullmatch(r"#[0-9A-Fa-f]{6}", color), (
         f"{agent_path}: invalid hex color '{color}' (expected #RRGGBB)"
     )
+
+
+@pytest.mark.parametrize("agent_name", _get_agent_files())
+def test_agent_tools_is_mapping(agent_name: str) -> None:
+    agent_path = AGENTS_DIR / f"{agent_name}.md"
+    content = agent_path.read_text()
+
+    parts = content.split("---", 2)
+    yaml_content = parts[1] if len(parts) >= 3 else ""
+
+    tools_match = re.search(r"^tools:\s*$", yaml_content, re.MULTILINE)
+    if tools_match is None:
+        pytest.skip(f"Agent '{agent_name}' has no tools field")
+
+    block_start = tools_match.end()
+    block_lines: list[str] = []
+    for line in yaml_content[block_start:].splitlines():
+        if line and not line.startswith((" ", "\t")):
+            break
+        if line.strip():
+            block_lines.append(line)
+
+    assert block_lines, f"{agent_path}: 'tools:' block is empty"
+
+    for line in block_lines:
+        stripped = line.strip()
+        assert not stripped.startswith("-"), (
+            f"{agent_path}: 'tools' must be a mapping (key: true), not a list. "
+            f"Offending line: {line!r}"
+        )
+        assert re.match(r"^\s+[A-Za-z_][A-Za-z0-9_]*:\s*(true|false)\s*$", line), (
+            f"{agent_path}: invalid tools entry {line!r} "
+            "(expected '  <tool>: true' or '  <tool>: false')"
+        )

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,7 +1,12 @@
 from pathlib import Path
 from textwrap import dedent
+from typing import cast
+from unittest.mock import MagicMock
+
+import pytest
 
 from scripts.setup import (
+    ToolConfig,
     apply_work_overlay,
     convert_md_to_toml,
     ensure_settings_from_template,
@@ -9,6 +14,7 @@ from scripts.setup import (
     generate_memory,
     parse_frontmatter,
     run_bootstrap,
+    setup_tool,
 )
 
 
@@ -269,3 +275,38 @@ def test_run_bootstrap_nonzero_exit(tmp_path: Path) -> None:
     script.write_text("#!/usr/bin/env bash\nexit 3\n")
 
     assert run_bootstrap(tmp_path, "bootstrap.sh") is False
+
+
+def test_setup_tool_skips_config_on_bootstrap_failure(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    ai_root = tmp_path / "ai"
+    tool_dir = ai_root / "modules" / "mytool"
+    tool_dir.mkdir(parents=True)
+    (tool_dir / "CONFIG.md").write_text("config")
+
+    config_dir = tmp_path / "cfg"
+
+    tool_config = cast(
+        ToolConfig,
+        {
+            "name": "MyTool",
+            "config_dir": str(config_dir),
+            "tool_dir": "modules/mytool",
+            "symlinks": [{"source": "CONFIG.md", "target": "CONFIG.md"}],
+            "bootstrap": "bootstrap.sh",
+        },
+    )
+
+    monkeypatch.setattr("scripts.setup.run_bootstrap", lambda *_: False)
+    mock_symlink = MagicMock()
+    mock_alias = MagicMock()
+    monkeypatch.setattr("scripts.setup.create_symlink", mock_symlink)
+    monkeypatch.setattr("scripts.setup.setup_shell_alias", mock_alias)
+
+    result = setup_tool("mytool", tool_config, ai_root)
+
+    assert result is False
+    assert mock_symlink.called is False
+    assert not (config_dir / "CONFIG.md").exists()
+    mock_alias.assert_called_once_with("mytool")

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,11 +1,9 @@
-import json
 from pathlib import Path
 from textwrap import dedent
 
 from scripts.setup import (
     apply_work_overlay,
     convert_md_to_toml,
-    deep_merge,
     ensure_settings_from_template,
     find_skill_files,
     generate_memory,
@@ -198,26 +196,6 @@ def test_ensure_settings_from_template_creates_from_template(tmp_path: Path) -> 
     assert '"from": "template"' in (tmp_path / "settings.json").read_text()
 
 
-def test_deep_merge() -> None:
-    base = {"a": 1, "b": {"c": 2, "d": 3}}
-    overlay = {"b": {"d": 99, "e": 4}, "f": 5}
-    assert deep_merge(base, overlay) == {"a": 1, "b": {"c": 2, "d": 99, "e": 4}, "f": 5}
-
-
-def test_deep_merge_leaves_base_untouched() -> None:
-    base = {"a": {"b": 1}}
-    overlay = {"a": {"c": 2}}
-    result = deep_merge(base, overlay)
-    assert base == {"a": {"b": 1}}
-    assert result == {"a": {"b": 1, "c": 2}}
-
-
-def test_deep_merge_overlay_replaces_non_dict() -> None:
-    base = {"a": [1, 2, 3], "b": {"x": 1}}
-    overlay = {"a": [9], "b": "scalar"}
-    assert deep_merge(base, overlay) == {"a": [9], "b": "scalar"}
-
-
 def test_apply_work_overlay_no_overlay(tmp_path: Path) -> None:
     ai_root = tmp_path / "ai"
     ai_root.mkdir()
@@ -225,45 +203,6 @@ def test_apply_work_overlay_no_overlay(tmp_path: Path) -> None:
     config_dir.mkdir()
 
     assert apply_work_overlay("ghost", config_dir, ai_root) is True
-
-
-def test_apply_work_overlay_merges_json(tmp_path: Path) -> None:
-    ai_root = tmp_path / "ai"
-    overlay = ai_root / "work" / "modules" / "mytool"
-    overlay.mkdir(parents=True)
-    (overlay / "config.json").write_text('{"providers": {"ic": {"url": "https://ic"}}}')
-
-    config_dir = tmp_path / "cfg"
-    config_dir.mkdir()
-    (config_dir / "config.json").write_text(
-        json.dumps({"permission": {"bash": "ask"}, "providers": {"openai": {"url": "oai"}}})
-    )
-
-    assert apply_work_overlay("mytool", config_dir, ai_root) is True
-
-    merged = json.loads((config_dir / "config.json").read_text())
-    assert merged["permission"] == {"bash": "ask"}
-    assert merged["providers"] == {"openai": {"url": "oai"}, "ic": {"url": "https://ic"}}
-
-
-def test_apply_work_overlay_breaks_symlink_before_writing(tmp_path: Path) -> None:
-    ai_root = tmp_path / "ai"
-    overlay = ai_root / "work" / "modules" / "mytool"
-    overlay.mkdir(parents=True)
-    (overlay / "config.json").write_text('{"extra": true}')
-
-    source = tmp_path / "source-config.json"
-    source.write_text('{"base": true}')
-    config_dir = tmp_path / "cfg"
-    config_dir.mkdir()
-    target = config_dir / "config.json"
-    target.symlink_to(source)
-
-    assert apply_work_overlay("mytool", config_dir, ai_root) is True
-
-    assert not target.is_symlink()
-    assert json.loads(target.read_text()) == {"base": True, "extra": True}
-    assert json.loads(source.read_text()) == {"base": True}
 
 
 def test_apply_work_overlay_runs_scripts(tmp_path: Path) -> None:
@@ -294,6 +233,22 @@ def test_apply_work_overlay_symlinks_other_files(tmp_path: Path) -> None:
     target = config_dir / "config.toml"
     assert target.is_symlink()
     assert target.resolve() == (overlay / "config.toml").resolve()
+
+
+def test_apply_work_overlay_symlinks_json(tmp_path: Path) -> None:
+    ai_root = tmp_path / "ai"
+    overlay = ai_root / "work" / "modules" / "mytool"
+    overlay.mkdir(parents=True)
+    (overlay / "opencode.json").write_text('{"providers": {"ic": {}}}')
+
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    assert apply_work_overlay("mytool", config_dir, ai_root) is True
+
+    target = config_dir / "opencode.json"
+    assert target.is_symlink()
+    assert target.resolve() == (overlay / "opencode.json").resolve()
 
 
 def test_run_bootstrap_success(tmp_path: Path) -> None:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -310,3 +310,51 @@ def test_setup_tool_skips_config_on_bootstrap_failure(
     assert mock_symlink.called is False
     assert not (config_dir / "CONFIG.md").exists()
     mock_alias.assert_called_once_with("mytool")
+
+
+def test_setup_tool_codex_symlinks_agents_without_backup(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """End-to-end codex flow with bootstrap mocked: no real npm/omx invocation.
+
+    Simulates `omx setup` writing a regular `AGENTS.md` into the config dir,
+    followed by the bootstrap script's cleanup of that regular file. Then lets
+    the real symlink step run. The target must end up as a symlink to the
+    source, with no `.backup.*` residue from earlier runs.
+    """
+    ai_root = tmp_path / "ai"
+    tool_dir = ai_root / "modules" / "codex"
+    tool_dir.mkdir(parents=True)
+    source_agents = tool_dir / "AGENTS.md"
+    source_agents.write_text("source agents")
+    (tool_dir / "bootstrap.sh").write_text("#!/usr/bin/env bash\n")
+
+    config_dir = tmp_path / "dot-codex"
+
+    tool_config = cast(
+        ToolConfig,
+        {
+            "name": "Codex CLI",
+            "config_dir": str(config_dir),
+            "tool_dir": "modules/codex",
+            "symlinks": [{"source": "AGENTS.md", "target": "AGENTS.md"}],
+            "bootstrap": "bootstrap.sh",
+        },
+    )
+
+    def fake_bootstrap(_tool_dir: Path, _script: str) -> bool:
+        config_dir.mkdir(parents=True, exist_ok=True)
+        agents = config_dir / "AGENTS.md"
+        agents.write_text("omx default")
+        if agents.exists() and not agents.is_symlink():
+            agents.unlink()
+        return True
+
+    monkeypatch.setattr("scripts.setup.run_bootstrap", fake_bootstrap)
+
+    assert setup_tool("codex", tool_config, ai_root) is True
+
+    deployed = config_dir / "AGENTS.md"
+    assert deployed.is_symlink()
+    assert deployed.resolve() == source_agents.resolve()
+    assert list(config_dir.glob("*.backup.*")) == []

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,12 +1,16 @@
+import json
 from pathlib import Path
 from textwrap import dedent
 
 from scripts.setup import (
+    apply_work_overlay,
     convert_md_to_toml,
+    deep_merge,
     ensure_settings_from_template,
     find_skill_files,
     generate_memory,
     parse_frontmatter,
+    run_bootstrap,
 )
 
 
@@ -192,3 +196,121 @@ def test_ensure_settings_from_template_creates_from_template(tmp_path: Path) -> 
 
     assert result is True
     assert '"from": "template"' in (tmp_path / "settings.json").read_text()
+
+
+def test_deep_merge() -> None:
+    base = {"a": 1, "b": {"c": 2, "d": 3}}
+    overlay = {"b": {"d": 99, "e": 4}, "f": 5}
+    assert deep_merge(base, overlay) == {"a": 1, "b": {"c": 2, "d": 99, "e": 4}, "f": 5}
+
+
+def test_deep_merge_leaves_base_untouched() -> None:
+    base = {"a": {"b": 1}}
+    overlay = {"a": {"c": 2}}
+    result = deep_merge(base, overlay)
+    assert base == {"a": {"b": 1}}
+    assert result == {"a": {"b": 1, "c": 2}}
+
+
+def test_deep_merge_overlay_replaces_non_dict() -> None:
+    base = {"a": [1, 2, 3], "b": {"x": 1}}
+    overlay = {"a": [9], "b": "scalar"}
+    assert deep_merge(base, overlay) == {"a": [9], "b": "scalar"}
+
+
+def test_apply_work_overlay_no_overlay(tmp_path: Path) -> None:
+    ai_root = tmp_path / "ai"
+    ai_root.mkdir()
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    assert apply_work_overlay("ghost", config_dir, ai_root) is True
+
+
+def test_apply_work_overlay_merges_json(tmp_path: Path) -> None:
+    ai_root = tmp_path / "ai"
+    overlay = ai_root / "work" / "modules" / "mytool"
+    overlay.mkdir(parents=True)
+    (overlay / "config.json").write_text('{"providers": {"ic": {"url": "https://ic"}}}')
+
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    (config_dir / "config.json").write_text(
+        json.dumps({"permission": {"bash": "ask"}, "providers": {"openai": {"url": "oai"}}})
+    )
+
+    assert apply_work_overlay("mytool", config_dir, ai_root) is True
+
+    merged = json.loads((config_dir / "config.json").read_text())
+    assert merged["permission"] == {"bash": "ask"}
+    assert merged["providers"] == {"openai": {"url": "oai"}, "ic": {"url": "https://ic"}}
+
+
+def test_apply_work_overlay_breaks_symlink_before_writing(tmp_path: Path) -> None:
+    ai_root = tmp_path / "ai"
+    overlay = ai_root / "work" / "modules" / "mytool"
+    overlay.mkdir(parents=True)
+    (overlay / "config.json").write_text('{"extra": true}')
+
+    source = tmp_path / "source-config.json"
+    source.write_text('{"base": true}')
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+    target = config_dir / "config.json"
+    target.symlink_to(source)
+
+    assert apply_work_overlay("mytool", config_dir, ai_root) is True
+
+    assert not target.is_symlink()
+    assert json.loads(target.read_text()) == {"base": True, "extra": True}
+    assert json.loads(source.read_text()) == {"base": True}
+
+
+def test_apply_work_overlay_runs_scripts(tmp_path: Path) -> None:
+    ai_root = tmp_path / "ai"
+    overlay = ai_root / "work" / "modules" / "mytool"
+    overlay.mkdir(parents=True)
+    marker = tmp_path / "ran.txt"
+    (overlay / "setup.sh").write_text(f"#!/usr/bin/env bash\necho ok > {marker}\n")
+
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    assert apply_work_overlay("mytool", config_dir, ai_root) is True
+    assert marker.read_text().strip() == "ok"
+
+
+def test_apply_work_overlay_symlinks_other_files(tmp_path: Path) -> None:
+    ai_root = tmp_path / "ai"
+    overlay = ai_root / "work" / "modules" / "mytool"
+    overlay.mkdir(parents=True)
+    (overlay / "config.toml").write_text("[profiles.work]\nmodel = 'x'\n")
+
+    config_dir = tmp_path / "cfg"
+    config_dir.mkdir()
+
+    assert apply_work_overlay("mytool", config_dir, ai_root) is True
+
+    target = config_dir / "config.toml"
+    assert target.is_symlink()
+    assert target.resolve() == (overlay / "config.toml").resolve()
+
+
+def test_run_bootstrap_success(tmp_path: Path) -> None:
+    marker = tmp_path / "ran.txt"
+    script = tmp_path / "bootstrap.sh"
+    script.write_text(f"#!/usr/bin/env bash\necho ok > {marker}\n")
+
+    assert run_bootstrap(tmp_path, "bootstrap.sh") is True
+    assert marker.read_text().strip() == "ok"
+
+
+def test_run_bootstrap_missing(tmp_path: Path) -> None:
+    assert run_bootstrap(tmp_path, "missing.sh") is False
+
+
+def test_run_bootstrap_nonzero_exit(tmp_path: Path) -> None:
+    script = tmp_path / "bootstrap.sh"
+    script.write_text("#!/usr/bin/env bash\nexit 3\n")
+
+    assert run_bootstrap(tmp_path, "bootstrap.sh") is False

--- a/tests/test_tasks.py
+++ b/tests/test_tasks.py
@@ -293,6 +293,7 @@ class TestTeardown:
                 ".claude/settings.json",
             ],
         )
+        monkeypatch.setattr("tasks._load_overlay_paths", lambda: [])
 
         configs = {
             ".zprofile": fake_home / ".zprofile",
@@ -341,6 +342,7 @@ class TestTeardown:
         mock_run = MagicMock()
         monkeypatch.setattr("tasks.subprocess.run", mock_run)
         monkeypatch.setattr("tasks._load_ai_tool_paths", lambda: [])
+        monkeypatch.setattr("tasks._load_overlay_paths", lambda: [])
 
         real_file = fake_home / "real_zprofile"
         real_file.write_text("real")
@@ -374,5 +376,6 @@ class TestTeardown:
         mock_run = MagicMock()
         monkeypatch.setattr("tasks.subprocess.run", mock_run)
         monkeypatch.setattr("tasks._load_ai_tool_paths", lambda: [])
+        monkeypatch.setattr("tasks._load_overlay_paths", lambda: [])
 
         _teardown()

--- a/tests/test_tools_config.py
+++ b/tests/test_tools_config.py
@@ -91,6 +91,18 @@ def test_memory_generate_source_exists(tools_config: dict[str, Any], ai_root: Pa
             )
 
 
+def test_agents_symlink_source_exists(tools_config: dict[str, Any], ai_root: Path) -> None:
+    for tool_id, tool in tools_config["tools"].items():
+        if "agents_symlink" in tool:
+            source = ai_root / tool["agents_symlink"]["source"]
+            assert source.exists(), (
+                f"Tool '{tool_id}' agents_symlink source does not exist: {source}"
+            )
+            assert source.is_dir(), (
+                f"Tool '{tool_id}' agents_symlink source is not a directory: {source}"
+            )
+
+
 def test_extra_skills_dirs_exist(tools_config: dict[str, Any], ai_root: Path) -> None:
     for _tool_id, tool in tools_config["tools"].items():
         for extra_dir in tool.get("extra_skills_dirs", []):


### PR DESCRIPTION
### Why are you making these changes?

Two scopes on one branch:

1. **Agent fleet expansion** — specialist skills for code review, exploration, simplification, QA planning, spec validation, and orchestrated workflows; OpenCode agents 1:1 with shared skills; new `agents_symlink` infrastructure in `setup.py`.
2. **Overlay + bootstrap hardening** — drop JSON deep-merge in favor of symlinking any non-`.sh` overlay file, extend teardown to cover overlay-deployed paths, gate tool config deployment on bootstrap success, and stop `omx setup` from leaving a regular `~/.codex/AGENTS.md` that the symlink step would back up on every run.

### How was this tested?

\`uv run pytest\` — 166 passed, 6 skipped. \`ruff check\`, \`ruff format --check\`, and \`mypy\` all clean. New tests cover: OpenCode agent frontmatter/body/colors, overlay JSON-symlink regression, and bootstrap-failure gating in \`setup_tool\`. Existing teardown tests updated to monkeypatch the new \`_load_overlay_paths\`. Manual end-to-end (\`inv reset && inv setup\` on codex, overlay teardown round-trip, simulated bootstrap failure) still pending on the user's machine.